### PR TITLE
feat: Windows dual-agent + registry tests + dual-agent CI/docs

### DIFF
--- a/.github/workflows/agent-selection-test.yml
+++ b/.github/workflows/agent-selection-test.yml
@@ -1,0 +1,145 @@
+name: agent-selection-test
+
+# Proves the dual-agent feature: the installer's agent choice (claude | codex |
+# both) installs the right binary/binaries and resolves the Phase 2 handoff to
+# the right agent. Secret-free by design — it sets ELNORA_SKIP_HANDOFF=1 so
+# setup prints "would hand off to <agent>" and exits 0 BEFORE any auth or real
+# agent launch. No ANTHROPIC_API_KEY / OPENAI_API_KEY needed.
+#
+# What the other agent E2Es prove (and this one deliberately does NOT):
+#   handoff-e2e.yml / bootstrap-e2e.yml — run the real agent (need API keys).
+#   install-smoke-test.yml             — Phase 1 install cleanliness (claude).
+# What THIS proves: the agent-selection branching in install.{sh,ps1} and
+#   setup-{mac.sh,windows.ps1} installs + routes to the chosen agent.
+#
+# A Codex *handoff* E2E (the agent actually following INSTALL_FOR_AGENTS.md
+# headless) is a follow-up: it needs an OPENAI_API_KEY repo secret and Codex's
+# transcript format wired into assertions. See README / the dual-agent PR notes.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - install.sh
+      - install.ps1
+      - setup-mac.sh
+      - setup-windows.ps1
+      - .github/workflows/agent-selection-test.yml
+
+permissions:
+  contents: read
+
+jobs:
+  macos:
+    name: macOS agent=${{ matrix.agent }}
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: [claude, codex, both]
+    runs-on: macos-14
+    timeout-minutes: 25
+    env:
+      ELNORA_AGENT: ${{ matrix.agent }}
+      # Skip the real handoff (no API key) and the heavy optional casks.
+      ELNORA_SKIP_HANDOFF: "1"
+      ELNORA_SKIP_OPTIONAL_INSTALLS: "1"
+      ELNORA_WORKSPACE_NAME: agent-sel-${{ github.run_id }}-${{ github.run_attempt }}-mac-${{ matrix.agent }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pre-set git config (skip prompts)
+        run: |
+          git config --global user.name "Agent Selection Test"
+          git config --global user.email "agent-selection@elnora-ai-agent-hackathon-starter-kit.test"
+
+      - name: Run Phase 1 setup with the selected agent
+        run: bash setup-mac.sh 2>&1 | tee "$HOME/setup-output.log"
+
+      - name: Assert the right agent(s) installed and handoff resolved
+        run: |
+          set -euo pipefail
+          out="$HOME/setup-output.log"
+          fail=0
+          want_claude=0; want_codex=0
+          case "$ELNORA_AGENT" in
+            claude) want_claude=1 ;;
+            codex)  want_codex=1 ;;
+            both)   want_claude=1; want_codex=1 ;;
+          esac
+
+          if [ "$want_claude" = "1" ]; then
+            command -v claude >/dev/null 2>&1 && echo "OK: claude installed" \
+              || { echo "FAIL: claude not on PATH"; fail=1; }
+          fi
+          if [ "$want_codex" = "1" ]; then
+            command -v codex >/dev/null 2>&1 && echo "OK: codex installed" \
+              || { echo "FAIL: codex not on PATH"; fail=1; }
+          fi
+
+          # With both installed, handoff defaults to claude (ELNORA_HANDOFF_AGENT
+          # unset). With a single agent, handoff is that agent.
+          case "$ELNORA_AGENT" in
+            codex) expect="would hand off to Codex" ;;
+            *)     expect="would hand off to Claude Code" ;;
+          esac
+          if grep -qF "$expect" "$out"; then
+            echo "OK: handoff resolved -> $expect"
+          else
+            echo "FAIL: expected handoff line not found: $expect"
+            fail=1
+          fi
+
+          exit "$fail"
+
+  windows:
+    name: Windows agent=${{ matrix.agent }}
+    strategy:
+      fail-fast: false
+      matrix:
+        agent: [claude, codex, both]
+    runs-on: windows-2022
+    timeout-minutes: 30
+    env:
+      ELNORA_AGENT: ${{ matrix.agent }}
+      ELNORA_SKIP_HANDOFF: "1"
+      ELNORA_SKIP_OPTIONAL_INSTALLS: "1"
+      ELNORA_WORKSPACE_NAME: agent-sel-${{ github.run_id }}-${{ github.run_attempt }}-win-${{ matrix.agent }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Pre-set git config (skip prompts)
+        shell: pwsh
+        run: |
+          git config --global user.name "Agent Selection Test"
+          git config --global user.email "agent-selection@elnora-ai-agent-hackathon-starter-kit.test"
+
+      - name: Run Phase 1 setup with the selected agent
+        shell: pwsh
+        run: .\setup-windows.ps1 *>&1 | Tee-Object -FilePath "$env:USERPROFILE\setup-output.log"
+
+      - name: Assert the right agent(s) installed and handoff resolved
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          $out  = Get-Content "$env:USERPROFILE\setup-output.log" -Raw
+          $fail = $false
+          $wantClaude = $env:ELNORA_AGENT -in @('claude','both')
+          $wantCodex  = $env:ELNORA_AGENT -in @('codex','both')
+
+          # Refresh PATH so binaries installed this run resolve.
+          $env:Path = [Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [Environment]::GetEnvironmentVariable("Path","User")
+
+          if ($wantClaude) {
+            if (Get-Command claude -ErrorAction SilentlyContinue) { Write-Host "OK: claude installed" }
+            else { Write-Host "FAIL: claude not on PATH"; $fail = $true }
+          }
+          if ($wantCodex) {
+            if (Get-Command codex -ErrorAction SilentlyContinue) { Write-Host "OK: codex installed" }
+            else { Write-Host "FAIL: codex not on PATH"; $fail = $true }
+          }
+
+          $expect = if ($env:ELNORA_AGENT -eq 'codex') { "would hand off to Codex" } else { "would hand off to Claude Code" }
+          if ($out -like "*$expect*") { Write-Host "OK: handoff resolved -> $expect" }
+          else { Write-Host "FAIL: expected handoff line not found: $expect"; $fail = $true }
+
+          if ($fail) { exit 1 }

--- a/.github/workflows/install-smoke-test.yml
+++ b/.github/workflows/install-smoke-test.yml
@@ -44,6 +44,7 @@ on:
       - "setup-windows.ps1"
       - "install.sh"
       - "install.ps1"
+      - "tests/registry/**"
       - ".github/workflows/install-smoke-test.yml"
       - ".github/scripts/lint-ascii.py"
   pull_request:
@@ -53,6 +54,7 @@ on:
       - "setup-windows.ps1"
       - "install.sh"
       - "install.ps1"
+      - "tests/registry/**"
       - ".github/workflows/install-smoke-test.yml"
       - ".github/scripts/lint-ascii.py"
 
@@ -76,6 +78,23 @@ jobs:
       - uses: actions/checkout@v6
       - name: Reject non-ASCII outside # comments
         run: python3 .github/scripts/lint-ascii.py
+
+  registry-unit:
+    # Fast, hermetic unit tests for the workspace registry in install.sh /
+    # install.ps1 (the dedup logic that stops re-runs from spawning duplicate
+    # folders). No network, no API key, no real install -- the tests extract
+    # the registry lib from the installers and exercise it directly, so they're
+    # safe to run on every PR. ubuntu-latest ships both bash and pwsh.
+    name: registry unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+      - name: Bash registry tests
+        run: bash tests/registry/registry_test.sh
+      - name: PowerShell registry tests
+        shell: pwsh
+        run: ./tests/registry/registry_test.ps1
 
   macos:
     name: macOS (setup-mac.sh)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,9 @@
 # Getting Started — First Steps After Install
 
-You've got Claude Code installed and running. Here's how to make the most of it.
+You've got your coding agent — **Claude Code or Codex** (whichever you picked at
+install, or both) — installed and running. Here's how to make the most of it.
+The commands and shortcuts below are Claude Code's; if you chose Codex, start it
+with `codex` and see its own `/help` for the equivalents.
 
 ---
 
@@ -78,6 +81,7 @@ The more context you give Claude in `CLAUDE.md`, the better it performs. Add:
 | Command | What it does |
 |---------|-------------|
 | `claude` | Start a new Claude Code conversation |
+| `codex` | Start a new Codex conversation (if you installed Codex) |
 | `/help` | Show all available commands |
 | `/plugins` | Browse and install plugins |
 | `/commit` | Commit your changes (if commit-commands plugin is installed) |
@@ -104,8 +108,8 @@ is idempotent and upgrades installed tools in place.
 ## Set up your GitHub repo manually (fallback)
 
 Phase 2 normally creates your private GitHub repo for you. If the automated
-flow didn't run (no Claude Pro/Max, install failure, or you ran setup
-without launching Claude after), here's the equivalent by hand. Run these
+flow didn't run (no agent plan/key, install failure, or you ran setup
+without launching the agent after), here's the equivalent by hand. Run these
 in the starter-kit directory:
 
 ```bash
@@ -138,8 +142,9 @@ fails" or "GitHub repo creation fails."
 ## Getting help
 
 - **Claude Code documentation**: https://docs.anthropic.com/en/docs/claude-code
-- **Report issues**: https://github.com/anthropics/claude-code/issues
+- **Claude Code issues**: https://github.com/anthropics/claude-code/issues
 - **Anthropic support**: https://support.anthropic.com
+- **Codex documentation & issues**: https://github.com/openai/codex
 - **Community**: https://github.com/anthropics/claude-code/discussions
 
 ---

--- a/install.ps1
+++ b/install.ps1
@@ -63,6 +63,11 @@ $userLower = ($env:USERNAME -as [string]).ToLowerInvariant() -replace '\s+', '-'
 if ([string]::IsNullOrWhiteSpace($userLower)) { $userLower = 'me' }
 $defaultName = "$userLower-agents"
 
+# >>> ELNORA_REGISTRY_LIB_START >>>
+# Everything between these two markers is self-contained (no dependency on the
+# rest of this script) so tests/registry/registry_test.ps1 can extract and
+# dot-source it directly, exercising the REAL code instead of a drifting copy.
+# If you add a registry helper, keep it inside the markers.
 # ---- Workspace registry ---------------------------------------------------
 # Single source of truth for "which folder is the real workspace", so a
 # stalled-and-retried install resumes the same folder instead of spawning
@@ -71,6 +76,10 @@ $defaultName = "$userLower-agents"
 # last_run); comment lines start with '#'. Mirrors install.sh.
 $RegistryDir  = Join-Path $env:APPDATA 'elnora'
 $RegistryFile = Join-Path $RegistryDir 'workspaces.tsv'
+
+# Current UTC timestamp. Factored out (mirrors install.sh's _registry_now) so
+# the registry unit test can stub it for deterministic assertions.
+function Get-RegistryNow { (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') }
 
 function Get-RegistryEntries {
     if (-not (Test-Path -LiteralPath $RegistryFile)) { return @() }
@@ -110,7 +119,7 @@ function Write-Registry {
 # Append or update one entry, preserving its original Created timestamp.
 function Set-RegistryEntry {
     param([string]$Name, [string]$Path)
-    $now = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+    $now = Get-RegistryNow
     $entries = @(Get-RegistryEntries)
     $created = $now
     $existing = $entries | Where-Object { $_.Path -eq $Path } | Select-Object -First 1
@@ -180,6 +189,7 @@ function Invoke-ResumeMenu {
         }
     }
 }
+# <<< ELNORA_REGISTRY_LIB_END <<<
 
 Write-Host ""
 Write-Host "===========================================" -ForegroundColor Cyan

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,11 @@ _user_lower="$(printf '%s' "${USER:-me}" \
 [ -z "$_user_lower" ] && _user_lower="me"
 default_name="${_user_lower}-agents"
 
+# >>> ELNORA_REGISTRY_LIB_START >>>
+# Everything between these two markers is self-contained (no dependency on the
+# rest of this script) so tests/registry/registry_test.sh can extract and
+# source it directly, exercising the REAL code instead of a drifting copy. If
+# you add a registry helper, keep it inside the markers.
 # ---- Workspace registry ---------------------------------------------------
 # Single source of truth for "which folder is the real workspace." Without it,
 # a customer whose first run died in Phase 2 re-runs this script, doesn't
@@ -179,6 +184,7 @@ registry_resume_menu() {
         esac
     done
 }
+# <<< ELNORA_REGISTRY_LIB_END <<<
 
 echo "==========================================="
 echo "  Elnora AI Agent Hackathon Starter Kit - Bootstrap"

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -330,8 +330,10 @@ agent_installed() { case "$ELNORA_AGENT" in "$1"|both) return 0 ;; *) return 1 ;
 # --- [1/9] AI coding agent(s) (installed FIRST - zero dependencies) ---
 # Both Claude Code and Codex ship self-contained native installers that need
 # no prerequisites (not even brew or node), so whichever the user picked is
-# the very first thing on the machine. Each writes its binary under
-# ~/.local/bin and auto-updates itself.
+# the very first thing on the machine, writing its binary under ~/.local/bin
+# and auto-updating itself. Codex's native installer host can be unreachable
+# from CI/datacenter IPs (HTTP 403); when that happens we transparently fall
+# back to the npm package after Node lands (see the fallback below step 3).
 if agent_installed claude; then
     if ! command -v claude &> /dev/null; then
         echo "[1/9] Installing Claude Code..."
@@ -352,13 +354,28 @@ if agent_installed claude; then
         echo "[1/9] Claude Code already installed: $(claude --version). Skipping."
     fi
 fi
+# Set when the native Codex installer can't run here, so the post-Node step
+# below retries via npm (mirrors setup-windows.ps1, which installs Codex from
+# npm after Node). chatgpt.com/codex/install.sh works for real users but is
+# blocked (HTTP 403) from some CI/datacenter IPs, so a hard failure here would
+# be wrong - we just defer to the reliable npm path.
+_codex_needs_npm=0
 if agent_installed codex; then
     if ! command -v codex &> /dev/null; then
         echo "[1/9] Installing Codex..."
-        echo "  Using OpenAI's native installer (no prerequisites required)."
-        if run_step "Codex" /bin/bash -c "set -o pipefail; curl -fsSL https://chatgpt.com/codex/install.sh | sh"; then
-            export PATH="$HOME/.local/bin:$PATH"
+        echo "  Trying OpenAI's native installer (no prerequisites required)."
+        # Don't route this through run_step: a non-zero exit here is recoverable
+        # (we fall back to npm after Node), so it must not land in FAILED_STEPS
+        # or print a scary remediation box. set -o pipefail propagates a failed
+        # curl through the pipe so we correctly detect the 403/network case.
+        /bin/bash -c "set -o pipefail; curl -fsSL https://chatgpt.com/codex/install.sh | sh" >/dev/null 2>&1 || true
+        export PATH="$HOME/.local/bin:$PATH"
+        hash -r 2>/dev/null || true
+        if command -v codex &> /dev/null; then
             echo "  Done. Version: $(codex --version 2>/dev/null || echo 'installed - restart terminal')"
+        else
+            echo "  Native installer unavailable here - will install Codex via npm after Node."
+            _codex_needs_npm=1
         fi
     else
         echo "[1/9] Codex already installed: $(codex --version). Skipping."
@@ -569,6 +586,23 @@ if ! $node_major_ok; then
     fi
 else
     echo "[3/9] Node.js already installed: $(node --version). Skipping."
+fi
+
+# Codex npm fallback: if the native installer at step 1 couldn't run (CI/
+# datacenter 403 on chatgpt.com, or no network yet), install it now that Node
+# and npm exist - the same path setup-windows.ps1 uses for Codex.
+if agent_installed codex && [ "${_codex_needs_npm:-0}" = "1" ] && ! command -v codex &> /dev/null; then
+    if command -v npm &> /dev/null; then
+        echo "[3/9] Installing Codex via npm (native installer was unreachable)..."
+        if run_step "Codex (npm)" npm install -g @openai/codex; then
+            hash -r 2>/dev/null || true
+            echo "  Done. Version: $(codex --version 2>/dev/null || echo 'installed - restart terminal')"
+        fi
+    else
+        echo "[3/9] Codex still not installed and npm is unavailable - install it"
+        echo "      manually after setup:  npm install -g @openai/codex"
+        FAILED_STEPS+=("Codex (no native installer, no npm)")
+    fi
 fi
 
 # --- [4/9] Git + user config ---

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -507,10 +507,26 @@ if (-not $hasWinget) {
     }
 }
 
+# --- Coding agent selection (set by install.ps1; default to claude) ---
+# $env:ELNORA_AGENT is claude | codex | both; $env:ELNORA_HANDOFF_AGENT
+# (claude | codex) finishes Phase 2. A direct setup-windows.ps1 run with no
+# install.ps1 defaults to claude so existing muscle memory still works.
+$Agent = ("$($env:ELNORA_AGENT)").ToLowerInvariant() -replace '\s',''
+if ($Agent -notin @('claude','codex','both')) { $Agent = 'claude' }
+if ($Agent -eq 'both') {
+    $HandoffAgent = ("$($env:ELNORA_HANDOFF_AGENT)").ToLowerInvariant() -replace '\s',''
+    if ($HandoffAgent -notin @('claude','codex')) { $HandoffAgent = 'claude' }
+} else {
+    $HandoffAgent = $Agent
+}
+# True when $which (claude|codex) is among the installed agent(s).
+function Test-AgentInstalled([string]$which) { return ($Agent -eq $which -or $Agent -eq 'both') }
+
 # --- [1/8] Claude Code CLI (installed FIRST - zero dependencies) ---
 # Using Anthropic's native installer so Claude Code is the very first thing on
 # the machine. Works even when winget is missing (unlike the rest of the tools
 # below). Writes a self-contained binary to %USERPROFILE%\.local\bin\claude.exe.
+if (Test-AgentInstalled 'claude') {
 if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
     Write-Host "[1/8] Installing Claude Code..." -ForegroundColor Green
     Write-Host "  Using Anthropic's native installer (no prerequisites required)." -ForegroundColor Gray
@@ -563,6 +579,7 @@ if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
 } else {
     Write-Host "[1/8] Claude Code already installed: $(claude --version). Skipping." -ForegroundColor Gray
 }
+}  # end if Test-AgentInstalled 'claude'
 
 # --- [2/8] Node.js (pinned to >=22 for Mac/Windows parity) ---
 # Mirror setup-mac.sh's major-version probe (lines 426-432). Bare
@@ -704,6 +721,31 @@ if (-not $nodeMajorOk) {
     }
 } else {
     Write-Host "[2/8] Node.js already installed: $nodeCurrentVersion. Skipping." -ForegroundColor Gray
+}
+
+# --- [2b/8] Codex CLI (after Node - the npm package needs it) ---
+# Codex ships a native installer for macOS/Linux only; on Windows the supported
+# path is the npm package, so this runs after Node above rather than first.
+if (Test-AgentInstalled 'codex') {
+    # Pick up a just-installed Node so `npm` resolves without a new terminal.
+    Update-SessionPath
+    if (-not (Get-Command codex -ErrorAction SilentlyContinue)) {
+        if (Get-Command npm -ErrorAction SilentlyContinue) {
+            Write-Host "[2b/8] Installing Codex (npm -g @openai/codex)..." -ForegroundColor Green
+            Invoke-Step "Codex" { npm install -g @openai/codex }
+            Update-SessionPath
+            if (Get-Command codex -ErrorAction SilentlyContinue) {
+                Write-Host "  Done. Version: $(codex --version 2>$null)" -ForegroundColor Gray
+            }
+        } else {
+            Write-Host "[2b/8] Codex needs Node/npm, which isn't on PATH yet." -ForegroundColor Red
+            Write-Host "      Open a new terminal (so the Node PATH refresh applies) and re-run," -ForegroundColor Yellow
+            Write-Host "      or install manually:  npm install -g @openai/codex" -ForegroundColor Yellow
+            [void]$FailedSteps.Add("Codex (npm unavailable)")
+        }
+    } else {
+        Write-Host "[2b/8] Codex already installed: $(codex --version). Skipping." -ForegroundColor Gray
+    }
 }
 
 # --- [3/8] Git + user config ---
@@ -1182,6 +1224,53 @@ if ($env:ELNORA_SKIP_HANDOFF -eq "1" -or $env:ELNORA_HANDOFF_MODE -eq "headless"
     Write-Host "  (Skipped -- non-interactive run.)"
     Write-Host ""
 } else {
+    # ---- Handoff-agent auth ----
+    # Only the agent that finishes Phase 2 ($HandoffAgent) must be signed in
+    # here. If both were installed, the other signs in on its own first launch.
+    if ($HandoffAgent -eq 'codex') {
+    Write-Host "[1/2] Codex"
+    $codexHome = if ($env:CODEX_HOME) { $env:CODEX_HOME } else { Join-Path $env:USERPROFILE '.codex' }
+    if ($env:OPENAI_API_KEY -or $env:CODEX_API_KEY) {
+        Write-Host "      OPENAI_API_KEY/CODEX_API_KEY set -- skipping browser login."
+    } elseif (Test-Path -LiteralPath (Join-Path $codexHome 'auth.json')) {
+        Write-Host "      [OK] Already signed in."
+        Set-Checkpoint "auth-codex"
+    } else {
+        Write-Host "      Not signed in. A browser will open so you can sign in to ChatGPT."
+        Write-Host "      [Y]es / [s]kip+continue without Codex / [q]uit script"
+        $answer = Read-Host "      >"
+        if ([string]::IsNullOrWhiteSpace($answer)) { $answer = "Y" }
+        switch -Regex ($answer) {
+            "^[Yy]" {
+                codex login
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Host "      [FAIL] Codex sign-in didn't complete."
+                    Write-Host ""
+                    Write-Host "         Nothing is lost. When you're ready, run again:"
+                    Write-Host ""
+                    Write-Host "             .\setup-windows.ps1"
+                    Write-Host ""
+                    Write-Host "         To try the login by hand first:  codex login"
+                    exit 1
+                }
+                Write-Host "      [OK] Signed in."
+                Set-Checkpoint "auth-codex"
+            }
+            "^[Ss]" {
+                Write-Host "      [SKIP] Phase 2 needs a signed-in agent. Re-run when ready:  .\setup-windows.ps1"
+                exit 0
+            }
+            "^[Qq]" {
+                Write-Host "      Quit. Re-run anytime:  .\setup-windows.ps1"
+                exit 0
+            }
+            default {
+                Write-Host "      Unrecognized response, treating as skip."
+                exit 0
+            }
+        }
+    }
+    } else {
     # ---- Claude auth ----
     Write-Host "[1/2] Claude Code"
     if ($env:ANTHROPIC_API_KEY) {
@@ -1287,6 +1376,17 @@ if ($env:ELNORA_SKIP_HANDOFF -eq "1" -or $env:ELNORA_HANDOFF_MODE -eq "headless"
             }
         }
     }
+    }  # end handoff-agent auth (codex / claude branch)
+
+    # When both agents were installed, the non-handoff one is optional here --
+    # it prompts for sign-in on its own first launch. Just remind the user.
+    if ($Agent -eq 'both') {
+        if ($HandoffAgent -eq 'claude') {
+            Write-Host "      Note: Codex is installed too -- sign in anytime with 'codex login'."
+        } else {
+            Write-Host "      Note: Claude Code is installed too -- sign in anytime with 'claude auth login --claudeai'."
+        }
+    }
     Write-Host ""
 
     # ---- GitHub auth ----
@@ -1364,14 +1464,25 @@ try { Stop-Transcript | Out-Null } catch { }
 # divergence here is the bug headless mode is supposed to catch.
 $HandoffPrompt = "Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at $env:USERPROFILE\claude-starter-install.log."
 
-$claudeAvailable = Get-Command claude -ErrorAction SilentlyContinue
-if ($claudeAvailable) {
+# Resolve the handoff agent's binary, display name, and first-run auth note.
+if ($HandoffAgent -eq 'codex') {
+    $agentBin  = 'codex'
+    $agentName = 'Codex'
+    $authNote  = "On first run, a browser may open so you can sign in to your ChatGPT (OpenAI) account."
+} else {
+    $agentBin  = 'claude'
+    $agentName = 'Claude Code'
+    $authNote  = "On first run, your browser will open to log into your Claude Pro/Max account."
+}
+
+$agentAvailable = Get-Command $agentBin -ErrorAction SilentlyContinue
+if ($agentAvailable) {
     if ($env:ELNORA_SKIP_HANDOFF -eq "1") {
         # CI/test escape hatch: print what would happen and exit cleanly. Used
         # by .github/workflows/install-smoke-test.yml so the smoke test doesn't
-        # hang on Claude trying to open a browser for first-run auth.
+        # hang on the agent trying to open a browser for first-run auth.
         # Echo the prompt itself so the smoke test has something to grep on.
-        Write-Host "ELNORA_SKIP_HANDOFF=1 set - would invoke claude with the Phase 2 prompt. Skipping for non-interactive run." -ForegroundColor Gray
+        Write-Host "ELNORA_SKIP_HANDOFF=1 set - would hand off to $agentName with the Phase 2 prompt. Skipping for non-interactive run." -ForegroundColor Gray
         Write-Host "  Phase 2 prompt: $HandoffPrompt" -ForegroundColor Gray
         exit 0
     }
@@ -1539,31 +1650,37 @@ if ($claudeAvailable) {
             exit 2
         }
         $transcript = if ($env:ELNORA_HANDOFF_TRANSCRIPT) { $env:ELNORA_HANDOFF_TRANSCRIPT } else { Join-Path $env:USERPROFILE "handoff-transcript.jsonl" }
-        Write-Host "ELNORA_HANDOFF_MODE=headless - running claude -p (transcript: $transcript)" -ForegroundColor Cyan
-        # --verbose is REQUIRED with -p --output-format=stream-json (Claude Code
-        # rejects the combo otherwise). --max-turns 80 caps a runaway loop;
-        # Phase 2 averages ~40-50 turns when GitHub bootstrap (gh auth + repo
-        # create + push + verify) runs in full, so 80 leaves ~30-turn
-        # headroom for transient retries (network, tool errors).
-        #
-        # The trailing `| Out-Null` is load-bearing (mirrors the Mac script's
-        # `> /dev/null` after `tee`): Start-Transcript captures everything
-        # written to the host, so without Out-Null the JSONL stream would land
-        # in BOTH the transcript file AND ~/claude-starter-install.log -
-        # bloating the install log and embedding the agent's own conversation
-        # (including the literal text "FAILED:" inside INSTALL_FOR_AGENTS.md)
-        # where the next agent's grep FAILED: will hit it as false positives.
-        # Send JSONL to transcript only; the workflow has a separate "Show
-        # handoff transcript" step for live debugging.
-        & claude -p $HandoffPrompt `
-            --permission-mode bypassPermissions `
-            --output-format stream-json `
-            --verbose `
-            --max-turns 80 `
-          | Tee-Object -FilePath $transcript | Out-Null
-        $rc = $LASTEXITCODE
+        # The trailing `| Out-Null` on each branch is load-bearing (mirrors the
+        # Mac script's `> /dev/null` after `tee`): without it the agent's own
+        # conversation stream (including the literal text "FAILED:" inside
+        # INSTALL_FOR_AGENTS.md) lands in ~/claude-starter-install.log and
+        # poisons the next agent's grep FAILED:. Send it to the transcript only.
+        if ($agentBin -eq 'codex') {
+            Write-Host "ELNORA_HANDOFF_MODE=headless - running codex exec (transcript: $transcript)" -ForegroundColor Cyan
+            # `codex exec` is the non-interactive analog of `claude -p`;
+            # --dangerously-bypass-approvals-and-sandbox is Codex's equivalent of
+            # --permission-mode bypassPermissions (nobody is there to approve
+            # tool calls). Gated by the same CI / local-opt-in checks above.
+            & codex exec $HandoffPrompt --dangerously-bypass-approvals-and-sandbox 2>&1 `
+              | Tee-Object -FilePath $transcript | Out-Null
+            $rc = $LASTEXITCODE
+        } else {
+            Write-Host "ELNORA_HANDOFF_MODE=headless - running claude -p (transcript: $transcript)" -ForegroundColor Cyan
+            # --verbose is REQUIRED with -p --output-format=stream-json (Claude Code
+            # rejects the combo otherwise). --max-turns 80 caps a runaway loop;
+            # Phase 2 averages ~40-50 turns when GitHub bootstrap (gh auth + repo
+            # create + push + verify) runs in full, so 80 leaves ~30-turn
+            # headroom for transient retries (network, tool errors).
+            & claude -p $HandoffPrompt `
+                --permission-mode bypassPermissions `
+                --output-format stream-json `
+                --verbose `
+                --max-turns 80 `
+              | Tee-Object -FilePath $transcript | Out-Null
+            $rc = $LASTEXITCODE
+        }
         Write-Host ""
-        Write-Host "claude -p exited with code $rc (transcript saved to $transcript)" -ForegroundColor Cyan
+        Write-Host "$agentName handoff exited with code $rc (transcript saved to $transcript)" -ForegroundColor Cyan
         exit $rc
     }
 
@@ -1589,15 +1706,18 @@ if ($claudeAvailable) {
         # named workspace file and set restoreWindows so the NEXT relaunch
         # reopens this project instead of an empty window.
         try { Initialize-VSCodeWorkspace } catch { }
-        Write-Host "Already inside VS Code - starting Claude in this terminal." -ForegroundColor White
-        Write-Host "On first run, your browser will open to log into your Claude Pro/Max account." -ForegroundColor White
+        Write-Host "Already inside VS Code - starting $agentName in this terminal." -ForegroundColor White
+        Write-Host $authNote -ForegroundColor White
         Write-Host ""
-        & claude $HandoffPrompt
+        & $agentBin $HandoffPrompt
         exit $LASTEXITCODE
     }
 
+    # The VS Code sentinel handoff drives `claude` specifically (run-handoff.ps1
+    # invokes claude), so it only applies when Claude is the handoff agent. Codex
+    # falls through to the terminal call below.
     $codeAvailable = Get-Command code -ErrorAction SilentlyContinue
-    if ($codeAvailable -and $env:ELNORA_SKIP_VSCODE_HANDOFF -ne "1") {
+    if ($agentBin -eq 'claude' -and $codeAvailable -and $env:ELNORA_SKIP_VSCODE_HANDOFF -ne "1") {
         $vscodeDir = Join-Path $scriptDir ".vscode"
         $sentinel  = Join-Path $vscodeDir ".handoff-pending"
         $helper    = Join-Path $vscodeDir "run-handoff.ps1"
@@ -1654,25 +1774,25 @@ if ($claudeAvailable) {
         }
     }
 
-    Write-Host "Starting Claude - it will read INSTALL_FOR_AGENTS.md and finish setup." -ForegroundColor White
-    Write-Host "On first run, your browser will open to log into your Claude Pro/Max account." -ForegroundColor White
+    Write-Host "Starting $agentName - it will read INSTALL_FOR_AGENTS.md and finish setup." -ForegroundColor White
+    Write-Host $authNote -ForegroundColor White
     Write-Host ""
-    # PowerShell has no `exec` - call claude as a child process and let it own
+    # PowerShell has no `exec` - call the agent as a child process and let it own
     # the terminal until it exits. Then the script exits cleanly.
-    & claude $HandoffPrompt
+    & $agentBin $HandoffPrompt
     exit 0
 }
 
-# Fallback: claude not on PATH (install of Claude Code itself failed) - show
-# the manual continuation path so the user can recover after fixing the issue.
-Write-Host "  ! 'claude' command not found - Claude Code install may have failed." -ForegroundColor Yellow
+# Fallback: handoff agent not on PATH (its install failed) - show the manual
+# continuation path so the user can recover after fixing the issue.
+Write-Host "  ! '$agentBin' command not found - $agentName install may have failed." -ForegroundColor Yellow
 Write-Host ""
 Write-Host "  See the remediation hints above. Once you've fixed it, re-run:" -ForegroundColor White
 Write-Host "      .\setup-windows.ps1"
 Write-Host ""
 Write-Host "  Or continue manually:" -ForegroundColor White
 Write-Host "      cd $(Get-Location)"
-Write-Host "      claude"
+Write-Host "      $agentBin"
 Write-Host "      Then say: 'Read INSTALL_FOR_AGENTS.md and finish setup.'"
 Write-Host ""
 

--- a/tests/registry/registry_test.ps1
+++ b/tests/registry/registry_test.ps1
@@ -1,0 +1,108 @@
+# ============================================================
+# Unit test for the install.ps1 workspace registry.
+#
+# Hermetic: no network, no install. It EXTRACTS the registry helpers from
+# install.ps1 (the block between the ELNORA_REGISTRY_LIB markers) and
+# dot-sources them, so it tests the real shipping code, not a copy that can
+# drift. Covers the data layer (record / forget / dedup / created-preservation)
+# -- the part that can silently corrupt a user's registry.
+#
+# The interactive resume menu uses Read-Host (console input), which isn't
+# scriptable cross-platform, so it's covered by the macOS pty test in
+# registry_test.sh and by manual validation, not here.
+#
+# Usage:  pwsh tests/registry/registry_test.ps1
+# Exit:   0 = all assertions passed, 1 = at least one failed.
+# ============================================================
+$ErrorActionPreference = 'Stop'
+
+$repoRoot  = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$installPs1 = Join-Path $repoRoot 'install.ps1'
+
+$script:pass = 0
+$script:fail = 0
+function Assert-Eq($expected, $actual, $msg) {
+    if ("$expected" -eq "$actual") {
+        $script:pass++
+        Write-Host "  ok   - $msg"
+    } else {
+        $script:fail++
+        Write-Host "  FAIL - $msg (expected [$expected], got [$actual])"
+    }
+}
+
+# Sandbox first. The lib sets $RegistryDir from $env:APPDATA at source time;
+# on Linux CI runners APPDATA is unset, so point it at the sandbox before
+# sourcing to avoid a null Join-Path. We override $RegistryDir/$RegistryFile
+# explicitly below anyway.
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("elnora-reg-" + [System.Guid]::NewGuid().ToString('N'))
+$env:APPDATA = $work
+
+# --- Extract and dot-source the real registry lib ---------------------------
+$inBlock = $false
+$libLines = foreach ($l in (Get-Content -LiteralPath $installPs1)) {
+    if ($l -match 'ELNORA_REGISTRY_LIB_START') { $inBlock = $true; continue }
+    if ($l -match 'ELNORA_REGISTRY_LIB_END')   { $inBlock = $false; continue }
+    if ($inBlock) { $l }
+}
+$lib = ($libLines -join "`n")
+if ($lib -notmatch 'function Set-RegistryEntry') {
+    Write-Host "[!] Could not extract the registry lib from $installPs1"
+    Write-Host "    (markers ELNORA_REGISTRY_LIB_START / _END missing or moved?)"
+    exit 1
+}
+Invoke-Expression $lib
+
+# Redirect the registry into the sandbox and make timestamps deterministic by
+# overriding Get-RegistryNow (defined inside the lib).
+$script:RegistryDir  = Join-Path $work 'cfg'
+$script:RegistryFile = Join-Path $RegistryDir 'workspaces.tsv'
+$script:FakeNow = '2026-01-01T00:00:00Z'
+function Get-RegistryNow { $script:FakeNow }
+
+function DataLines { @(Get-RegistryEntries) }
+
+try {
+    Write-Host "registry data-layer tests"
+
+    # T1: no file yet -> Get-RegistryEntries returns empty.
+    Assert-Eq 0 (DataLines).Count "no registry file -> 0 entries"
+
+    # T2: first record creates the file with one entry.
+    Set-RegistryEntry -Name 'carmen-agents' -Path '/Users/x/Documents/carmen-agents'
+    Assert-Eq 1 (DataLines).Count "first record -> 1 entry"
+    Assert-Eq 'carmen-agents' ((DataLines)[0].Name) "first record stores the name"
+
+    # T3: a second distinct path appends.
+    Set-RegistryEntry -Name 'old-agents' -Path '/Users/x/Documents/old-agents'
+    Assert-Eq 2 (DataLines).Count "second distinct record -> 2 entries"
+
+    # T4: re-record same path -> no dup; created preserved, last_run advances.
+    $script:FakeNow = '2026-02-02T22:22:22Z'
+    Set-RegistryEntry -Name 'carmen-agents' -Path '/Users/x/Documents/carmen-agents'
+    Assert-Eq 2 (DataLines).Count "re-record same path -> still 2 entries (no dup)"
+    $e = @(Get-RegistryEntries) | Where-Object { $_.Path -eq '/Users/x/Documents/carmen-agents' } | Select-Object -First 1
+    Assert-Eq '2026-01-01T00:00:00Z' $e.Created "re-record preserves original created"
+    Assert-Eq '2026-02-02T22:22:22Z' $e.LastRun "re-record advances last_run"
+
+    # T5: forget removes only the targeted entry.
+    Remove-RegistryEntry -Path '/Users/x/Documents/old-agents'
+    Assert-Eq 1 (DataLines).Count "forget -> 1 entry"
+    Assert-Eq 'carmen-agents' ((DataLines)[0].Name) "forget removes the right entry"
+
+    # T6: header comment lines are preserved.
+    $comments = @(Get-Content -LiteralPath $RegistryFile | Where-Object { $_ -match '^\s*#' })
+    Assert-Eq 2 $comments.Count "two header comment lines kept"
+
+    # T7: tab-delimited storage tolerates spaces in a path.
+    Set-RegistryEntry -Name 'spacey' -Path '/Users/x/Documents/my agents'
+    $sp = @(Get-RegistryEntries) | Where-Object { $_.Path -eq '/Users/x/Documents/my agents' } | Select-Object -First 1
+    Assert-Eq 'spacey' $sp.Name "path containing a space round-trips"
+}
+finally {
+    if (Test-Path -LiteralPath $work) { Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue }
+}
+
+Write-Host ""
+Write-Host "registry tests: $($script:pass) passed, $($script:fail) failed"
+if ($script:fail -ne 0) { exit 1 } else { exit 0 }

--- a/tests/registry/registry_test.sh
+++ b/tests/registry/registry_test.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# ============================================================
+# Unit test for the install.sh workspace registry.
+#
+# Hermetic: no network, no API key, no real install. It EXTRACTS the registry
+# helpers from install.sh (the block between the ELNORA_REGISTRY_LIB markers)
+# and sources them, so it tests the real shipping code, not a copy that can
+# drift. The data layer (record / forget / dedup / created-preservation) is the
+# part that can silently corrupt a user's registry, so that's what we lock down.
+#
+# The interactive resume menu reads from /dev/tty, so it's only exercised when a
+# `script`-style pty is available (local macOS dev); in CI that part is skipped
+# with a SKIP line rather than failing.
+#
+# Usage:  bash tests/registry/registry_test.sh
+# Exit:   0 = all assertions passed, 1 = at least one failed.
+# ============================================================
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/install.sh"
+
+pass=0
+fail=0
+ok()   { pass=$((pass + 1)); printf '  ok   - %s\n' "$1"; }
+bad()  { fail=$((fail + 1)); printf '  FAIL - %s\n' "$1"; }
+# assert_eq EXPECTED ACTUAL MESSAGE
+assert_eq() { if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (expected [$1], got [$2])"; fi; }
+
+# --- Extract and source the real registry lib -------------------------------
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+LIB="$WORK/lib.sh"
+awk '/ELNORA_REGISTRY_LIB_START/{f=1;next} /ELNORA_REGISTRY_LIB_END/{f=0} f' "$INSTALL_SH" > "$LIB"
+
+if ! grep -q 'registry_record()' "$LIB"; then
+    echo "[!] Could not extract the registry lib from $INSTALL_SH"
+    echo "    (markers ELNORA_REGISTRY_LIB_START / _END missing or moved?)"
+    exit 1
+fi
+# shellcheck disable=SC1090
+. "$LIB"
+
+# Redirect the registry into our sandbox and make timestamps deterministic.
+REGISTRY_DIR="$WORK/cfg"
+REGISTRY_FILE="$REGISTRY_DIR/workspaces.tsv"
+NOW="2026-01-01T00:00:00Z"
+_registry_now() { echo "$NOW"; }
+
+datalines() { awk -F'\t' '!/^#/ && NF>=2' "$REGISTRY_FILE" 2>/dev/null; }
+field() { awk -F'\t' -v p="$2" -v c="$3" '!/^#/ && $2==p {print $c; exit}' "$REGISTRY_FILE"; }
+
+echo "registry data-layer tests"
+
+# T1: no registry file yet -> resume menu bails without touching the tty.
+( registry_resume_menu )
+assert_eq "1" "$?" "resume menu returns 1 when no registry exists"
+
+# T2: first record creates the file with exactly one data line.
+registry_record "carmen-agents" "/Users/x/Documents/carmen-agents"
+assert_eq "1" "$(datalines | wc -l | tr -d ' ')" "first record -> 1 data line"
+assert_eq "carmen-agents" "$(field x "/Users/x/Documents/carmen-agents" 1)" "first record stores the name"
+
+# T3: a second, different path appends a second line.
+registry_record "old-agents" "/Users/x/Documents/old-agents"
+assert_eq "2" "$(datalines | wc -l | tr -d ' ')" "second distinct record -> 2 data lines"
+
+# T4: re-recording the SAME path must not duplicate; created is preserved,
+#     last_run advances.
+NOW="2026-02-02T22:22:22Z"
+registry_record "carmen-agents" "/Users/x/Documents/carmen-agents"
+assert_eq "2" "$(datalines | wc -l | tr -d ' ')" "re-record same path -> still 2 data lines (no dup)"
+assert_eq "2026-01-01T00:00:00Z" "$(field x "/Users/x/Documents/carmen-agents" 3)" "re-record preserves original created"
+assert_eq "2026-02-02T22:22:22Z" "$(field x "/Users/x/Documents/carmen-agents" 4)" "re-record advances last_run"
+
+# T5: forget removes only the targeted entry.
+registry_forget "/Users/x/Documents/old-agents"
+assert_eq "1" "$(datalines | wc -l | tr -d ' ')" "forget -> 1 data line"
+assert_eq "carmen-agents" "$(datalines | awk -F'\t' '{print $1}')" "forget removes the right entry"
+
+# T6: header comment lines are always preserved (parser must skip them).
+assert_eq "2" "$(grep -c '^#' "$REGISTRY_FILE")" "two header comment lines kept"
+
+# T7: tab-delimited storage tolerates spaces in a path.
+registry_record "spacey" "/Users/x/Documents/my agents"
+assert_eq "spacey" "$(field x "/Users/x/Documents/my agents" 1)" "path containing a space round-trips"
+
+# --- Optional: drive the interactive menu through a pty ---------------------
+# Only when a usable `script` is present. The invocation differs between the
+# BSD `script` (macOS) and util-linux `script` (most CI), so we detect and skip
+# cleanly when we can't drive a pty rather than failing the suite.
+echo "resume-menu interactive tests"
+run_menu() {  # stdin = keystrokes; echoes the menu's RESULT line
+    local keys="$1" runner="$WORK/run.sh"
+    cat > "$runner" <<RUNEOF
+. "$LIB"
+REGISTRY_DIR="$REGISTRY_DIR"; REGISTRY_FILE="$REGISTRY_FILE"
+WORKSPACE_NAME=""
+if registry_resume_menu; then echo "RESULT:resume=\$WORKSPACE_NAME"; else echo "RESULT:fresh"; fi
+RUNEOF
+    if script --version 2>&1 | grep -qi 'util-linux'; then
+        printf '%s' "$keys" | script -qec "bash '$runner'" /dev/null 2>/dev/null
+    else
+        printf '%s' "$keys" | script -q /dev/null bash "$runner" 2>/dev/null
+    fi
+}
+
+if command -v script >/dev/null 2>&1; then
+    # Seed: one ready folder, one missing folder.
+    mkdir -p "$WORK/ready"
+    : > "$REGISTRY_FILE"
+    {
+        printf '# h1\n# h2\n'
+        printf 'ready-ws\t%s\t%s\t%s\n' "$WORK/ready" "$NOW" "$NOW"
+        printf 'gone-ws\t%s\t%s\t%s\n' "$WORK/gone"  "$NOW" "$NOW"
+    } > "$REGISTRY_FILE"
+
+    out="$(run_menu '1
+')"
+    case "$out" in *"RESULT:resume=ready-ws"*) ok "menu: pick ready -> resume=ready-ws" ;;
+        *) bad "menu: pick ready (got: $(printf '%s' "$out" | tr -d '\r' | grep RESULT))" ;; esac
+
+    out="$(run_menu 'n
+')"
+    case "$out" in *"RESULT:fresh"*) ok "menu: choose 'n' -> fresh prompt" ;;
+        *) bad "menu: choose 'n' (got: $(printf '%s' "$out" | tr -d '\r' | grep RESULT))" ;; esac
+
+    out="$(run_menu '2
+r
+')"
+    case "$out" in *"RESULT:resume=gone-ws"*) ok "menu: missing folder -> [r] recreate" ;;
+        *) bad "menu: missing -> recreate (got: $(printf '%s' "$out" | tr -d '\r' | grep RESULT))" ;; esac
+else
+    echo "  SKIP - no 'script' utility; interactive menu validated by data-layer + manual test"
+fi
+
+echo ""
+echo "registry tests: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
## Summary

Captures all remaining in-flight starter-kit work on top of the now-merged
multi-agent PR (#2). Brings the Windows path and CI to parity with the macOS
dual-agent feature and adds hermetic registry tests. Nothing left on side
branches.

## Commits

- `feat: dual-agent install/auth/handoff in setup-windows.ps1` — Windows mirror of the macOS dual-agent work; honors `ELNORA_AGENT` (claude|codex|both) and `ELNORA_HANDOFF_AGENT`, gating each install step and routing the handoff to the chosen agent (`claude -p` / `codex exec`).
- `test: add registry unit tests; bracket registry lib for extraction` — hermetic bash + PowerShell data-layer tests that extract the real registry helpers from `install.{sh,ps1}` (between `ELNORA_REGISTRY_LIB` markers) so the test can't drift from a copy.
- `ci: run hermetic registry unit tests on every PR`
- `ci: secret-free agent-selection + install-branching test` — proves the installer's agent choice installs the right binary and resolves the Phase 2 handoff, with no API keys (`ELNORA_SKIP_HANDOFF=1`).
- `docs: getting-started covers Codex alongside Claude Code`

## Verification

- `tests/registry/registry_test.sh` — 14/14 passing locally.
- PowerShell registry test + the two new CI workflows exercise the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
