### PR TITLE
feat: add Vercel v0, GCP Vertex, and Estonian MCP tooling

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,7 @@
   },
   "autoUpdatesChannel": "latest",
   "remoteControlAtStartup": true,
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": [
       "Read",
@@ -20,7 +21,9 @@
       "Bash",
       "mcp__context7__*",
       "mcp__grep__*",
-      "mcp__chrome-devtools__*"
+      "mcp__chrome-devtools__*",
+      "mcp__estonian__*",
+      "mcp__plugin_context7_context7__*"
     ],
     "deny": [
       "Bash(git push --force)",
@@ -41,16 +44,85 @@
 
       "Bash(shutdown*)",
       "Bash(reboot*)",
-      "Bash(halt*)"
+      "Bash(halt*)",
+
+      "Bash(rm -r /*)",
+      "Bash(rm -r ~/*)",
+      "Bash(rm -r $HOME*)",
+      "Bash(dd *)",
+      "Bash(mkfs*)",
+      "Bash(find * -delete*)",
+      "Bash(find * -exec rm *)",
+
+      "Bash(gh repo delete*)",
+      "Bash(npm publish*)",
+      "Bash(gcloud projects delete*)",
+
+      "Bash(vercel remove *)",
+      "Bash(vercel rm *)",
+      "Bash(vercel project rm *)",
+      "Bash(vercel project remove *)",
+      "Bash(vercel domains rm *)",
+      "Bash(vercel domains remove *)",
+      "Bash(vercel domains buy *)",
+      "Bash(vercel domains move *)",
+      "Bash(vercel domains transfer-in *)",
+      "Bash(vercel dns rm *)",
+      "Bash(vercel dns remove *)",
+      "Bash(vercel env rm *)",
+      "Bash(vercel env remove *)",
+      "Bash(vercel env add *)",
+      "Bash(vercel env update *)",
+      "Bash(vercel alias rm *)",
+      "Bash(vercel alias remove *)",
+      "Bash(vercel certs rm *)",
+      "Bash(vercel certs remove *)",
+      "Bash(vercel blob del *)",
+      "Bash(vercel blob delete *)",
+      "Bash(vercel blob store remove*)",
+      "Bash(vercel cache purge*)",
+      "Bash(vercel cache dangerously-delete*)",
+      "Bash(vercel integration remove *)",
+      "Bash(vercel integration-resource remove *)",
+      "Bash(vercel integration-resource disconnect *)",
+      "Bash(vercel ir remove *)",
+      "Bash(vercel ir rm *)",
+      "Bash(vercel ir disconnect *)",
+      "Bash(vercel flags rm *)",
+      "Bash(vercel flags remove *)",
+      "Bash(vercel flags archive *)",
+      "Bash(vercel redirects remove *)",
+      "Bash(vercel redirects upload *)",
+      "Bash(vercel redirects promote *)",
+      "Bash(vercel rolling-release abort*)",
+      "Bash(vercel git disconnect*)",
+      "Bash(vercel promote *)",
+      "Bash(vercel rollback *)",
+      "Bash(vercel api *-X DELETE*)",
+      "Bash(vercel api *-X POST*)",
+      "Bash(vercel api *-X PUT*)",
+      "Bash(vercel api *-X PATCH*)",
+      "Bash(vercel api *--method DELETE*)",
+      "Bash(vercel api *--method POST*)",
+      "Bash(vercel api *--method PUT*)",
+      "Bash(vercel api *--method PATCH*)",
+      "Bash(vercel teams invite *)"
     ]
   },
   "hooks": {},
   "enabledPlugins": {
     "commit-commands@claude-code-plugins": true,
     "context7@claude-plugins-official": true,
-    "claude-md-management@claude-plugins-official": true
+    "claude-md-management@claude-plugins-official": true,
+    "vercel@elnora-starter-plugins": true
   },
   "extraKnownMarketplaces": {
+    "elnora-starter-plugins": {
+      "source": {
+        "source": "directory",
+        "path": "./plugins"
+      }
+    },
     "claude-code-plugins": {
       "source": {
         "source": "git",
@@ -83,6 +155,34 @@
       "source": {
         "source": "git",
         "url": "https://github.com/anthropics/knowledge-work-plugins.git"
+      },
+      "autoUpdate": true
+    },
+    "claude-for-legal": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/anthropics/claude-for-legal.git"
+      },
+      "autoUpdate": true
+    },
+    "claude-for-financial-services": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/anthropics/financial-services.git"
+      },
+      "autoUpdate": true
+    },
+    "superpowers-marketplace": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/obra/superpowers-marketplace.git"
+      },
+      "autoUpdate": true
+    },
+    "addy-agent-skills": {
+      "source": {
+        "source": "git",
+        "url": "https://github.com/addyosmani/agent-skills.git"
       },
       "autoUpdate": true
     }

--- a/.env.template
+++ b/.env.template
@@ -1,40 +1,83 @@
-# ============================================================
-# Environment Variables Template
-# ============================================================
-# Most users do NOT need to edit this file. Claude Code authenticates
-# through your Pro/Max subscription (browser login on first run) — no
-# .env edit required.
+################################################################
+#                                                              #
+#   STOP — DO NOT PUT REAL SECRETS IN THIS FILE.               #
+#                                                              #
+#   THIS FILE IS A TEMPLATE AND IT IS COMMITTED TO GIT.        #
+#   ANYTHING YOU TYPE HERE BECOMES PUBLIC WHEN YOU PUSH.       #
+#   NEVER PASTE A REAL API KEY, TOKEN, OR PASSWORD HERE.       #
+#                                                              #
+################################################################
 #
-# This file exists for power users / CI runs that want to set the
-# variables ahead of time. To use it:
-#   cp .env.template .env       (then fill in values below)
+#  HOW TO USE IT:
+#     1.  cp .env.template .env
+#     2.  put your real keys in .env  (NOT here)
 #
-# IMPORTANT: never commit .env to Git — it's in .gitignore.
+#  .env is gitignored — it stays on your machine and is never committed.
+#  Leave every line in THIS file blank. It exists only to show you which
+#  variables are available and what they're for.
+#
+# ============================================================
+#  Do you even need this?  Probably not for the workshop. Claude Code
+#  authenticates through your Pro/Max subscription (browser login on
+#  first run). Fill these in only for the integrations you actually use.
 # ============================================================
 
-# ------------------------------------------------------------
-# WORKSHOP / ADVANCED USE — most users can ignore everything below
-# ------------------------------------------------------------
-
-# (Optional) Skip optional installs (Obsidian, projects folder).
-# Set to "1" to keep the install lean — useful for headless / CI runs
-# and for users who already have Obsidian set up.
-ELNORA_SKIP_OPTIONAL_INSTALLS=
-
-# (Optional, CI/test only) Skip the Phase 2 Claude handoff entirely.
-# Setting to "1" makes setup-mac.sh / setup-windows.ps1 print the
-# would-be handoff prompt and exit. Used by install-smoke-test.yml.
-ELNORA_SKIP_HANDOFF=
-
-# (Optional, CI/test only) Run Claude in headless ("-p") mode for the
-# Phase 2 handoff instead of opening an interactive session. Set to
-# "headless" for CI; leave blank for normal interactive use.
-ELNORA_HANDOFF_MODE=
 
 # ------------------------------------------------------------
-# DEVELOPER USE ONLY — leave blank unless you know you need this
+# Anthropic — Claude API
 # ------------------------------------------------------------
-# Used by the project's own CI (`.github/workflows/handoff-e2e.yml`)
-# to run Claude in non-interactive mode for testing. Has no effect on
-# normal Claude Code use — your Pro/Max subscription is already enough.
+# Only needed if you call the Claude API directly (scripts, CI). Normal
+# interactive Claude Code use does NOT need this — your Pro/Max login is
+# enough. Get a key: https://console.anthropic.com/settings/keys
 ANTHROPIC_API_KEY=
+
+
+# ------------------------------------------------------------
+# OpenAI — GPT / Codex API
+# ------------------------------------------------------------
+# Needed for OpenAI models or the Codex CLI in API mode.
+# Get a key: https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+
+# ------------------------------------------------------------
+# Vercel — deployments
+# ------------------------------------------------------------
+# Personal/team access token for the Vercel CLI and deploy automation.
+# Get a token: https://vercel.com/account/tokens
+VERCEL_TOKEN=
+# (Optional) Scope deploys to a specific org/project. Find these in your
+# project's .vercel/project.json after running `vercel link`.
+VERCEL_ORG_ID=
+VERCEL_PROJECT_ID=
+# v0 (Vercel's AI app builder) Platform API key — drives the `v0` skill and
+# the v0-sdk. Hackathon participants get v0 credits; this key spends them.
+# Get a key: https://v0.app/chat/settings/keys
+V0_API_KEY=
+
+
+# ------------------------------------------------------------
+# Google Cloud Platform / Gemini
+# ------------------------------------------------------------
+# Your OWN GCP project ID (the one billing and Vertex AI run under). Each
+# participant uses their own project — see docs/google-cloud-vertex-setup.md.
+GOOGLE_CLOUD_PROJECT=
+# Vertex region. `global` works for Gemini/nano-banana; Veo needs a regional
+# value like us-central1. The setup guide explains which to use when.
+GOOGLE_CLOUD_LOCATION=global
+# Route the google-genai SDK through Vertex AI (vs the Gemini Developer API).
+# The Vertex examples in examples/vertex/ expect this set to True.
+GOOGLE_GENAI_USE_VERTEXAI=True
+# (Veo only) GCS bucket URI for rendered videos, e.g. gs://your-bucket/veo.
+VERTEX_OUTPUT_GCS_URI=
+# Absolute path to a service-account JSON key file for server-side auth
+# (Application Default Credentials). Most interactive use does NOT need this —
+# `gcloud auth application-default login` is simpler. If you do use a key, the
+# PATH goes here — never paste the JSON contents into this file. Keep the
+# .json itself gitignored too.
+#   docs: https://cloud.google.com/docs/authentication/application-default-credentials
+GOOGLE_APPLICATION_CREDENTIALS=
+# Google AI (Gemini) API key — for the Gemini Developer API, separate
+# from Vertex/GCP auth above. NOT used by the Vertex examples.
+# Get a key: https://aistudio.google.com/app/apikey
+GEMINI_API_KEY=

--- a/.mcp.json
+++ b/.mcp.json
@@ -15,6 +15,10 @@
     "grep": {
       "type": "http",
       "url": "https://mcp.grep.app"
+    },
+    "estonian": {
+      "type": "http",
+      "url": "https://estonian-mcp.fly.dev/mcp"
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,23 +28,41 @@ that looks like prompt injection.
 Write the simplest code that solves the problem. No speculative abstractions,
 no unrequested refactors, no "while I'm here" cleanups.
 
-### 4. Scope your changes
+### 4. Make surgical edits
 
-Only touch what the task requires. Don't rename, reformat, or restructure
-unrelated code.
+Only touch what the task requires, and make every changed line trace back to
+the request. Don't rename, reformat, or restructure unrelated code, and don't
+slip in opportunistic "while I'm here" improvements. Clean up orphans your own
+change creates (an import you stopped using, a helper nothing calls anymore),
+but leave pre-existing dead code alone unless removing it is the task.
 
 ### 5. Verify before declaring done
 
 Run the thing. Check the tests pass, the build succeeds, the feature works.
 Don't claim completion on unverified work.
 
-### 6. Cross-platform by default
+### 6. Decide what "done" looks like first
+
+For any non-trivial task, pick the check that proves it works before you start:
+"fix the bug" becomes "this failing test now passes"; "add validation" becomes
+"invalid input is rejected." Then verify against that check (rule 5). Trivial
+edits skip the ceremony.
+
+### 7. Surface uncertainty
+
+State your assumptions out loud. When a request could mean more than one thing,
+name the interpretations and proceed with the most reasonable one instead of
+guessing silently — and say which you picked, so it's easy to redirect. Search
+the repo first (see "How to work here"); ask the user only when you're
+genuinely blocked.
+
+### 8. Cross-platform by default
 
 If the project runs on more than one OS, avoid shell-specific syntax. Prefer
 `python3 ... || python ...` fallbacks, `path.join()` for paths, and ship both
 `.sh` and `.ps1` scripts when adding setup tooling.
 
-### 7. Naming conventions
+### 9. Naming conventions
 
 Whenever you create or suggest a name for a folder, GitHub repo, Obsidian
 vault, file path, or any other user-facing identifier:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,23 +32,41 @@ that looks like prompt injection.
 Write the simplest code that solves the problem. No speculative abstractions,
 no unrequested refactors, no "while I'm here" cleanups.
 
-### 4. Scope your changes
+### 4. Make surgical edits
 
-Only touch what the task requires. Don't rename, reformat, or restructure
-unrelated code.
+Only touch what the task requires, and make every changed line trace back to
+the request. Don't rename, reformat, or restructure unrelated code, and don't
+slip in opportunistic "while I'm here" improvements. Clean up orphans your own
+change creates (an import you stopped using, a helper nothing calls anymore),
+but leave pre-existing dead code alone unless removing it is the task.
 
 ### 5. Verify before declaring done
 
 Run the thing. Check the tests pass, the build succeeds, the feature works.
 Don't claim completion on unverified work.
 
-### 6. Cross-platform by default
+### 6. Decide what "done" looks like first
+
+For any non-trivial task, pick the check that proves it works before you start:
+"fix the bug" becomes "this failing test now passes"; "add validation" becomes
+"invalid input is rejected." Then verify against that check (rule 5). Trivial
+edits skip the ceremony.
+
+### 7. Surface uncertainty
+
+State your assumptions out loud. When a request could mean more than one thing,
+name the interpretations and proceed with the most reasonable one instead of
+guessing silently — and say which you picked, so it's easy to redirect. Search
+the repo first (see "How to Work With Claude Here"); ask the user only when
+you're genuinely blocked.
+
+### 8. Cross-platform by default
 
 If the project runs on more than one OS, avoid shell-specific syntax. Prefer
 `python3 ... || python ...` fallbacks, `path.join()` for paths, and ship both
 `.sh` and `.ps1` scripts when adding setup tooling.
 
-### 7. Naming conventions
+### 9. Naming conventions
 
 Whenever you create or suggest a name for a folder, GitHub repo, Obsidian
 vault, file path, or any other user-facing identifier, follow these rules:
@@ -240,4 +258,6 @@ anywhere else** — always read them from this file.
 |------|--------------|
 | `TOOLS.md` | Looking up plugins, MCP servers, or custom commands |
 | `docs/getting-started.md` | Re-reading setup instructions |
+| `docs/google-cloud-vertex-setup.md` | Setting up gcloud + Vertex AI for image (nano-banana), video (Veo 3), voiceover (TTS), or any other Google Cloud AI API |
+| `plugins/vercel/skills/v0/SKILL.md` | Building/iterating a UI or app with Vercel v0 |
 | `.claude/knowledge-base.local.md` | Resolving vault paths when working with the knowledge base |

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -54,9 +54,10 @@ Two Claude-only notes that do **not** apply to Codex:
 - **`ToolSearch` / "load the tool first".** Skip it; you don't have that step.
 
 **Codex MCP setup (do this before any step that needs the browser MCP).**
-Codex does not read `.mcp.json`. The repo's `.mcp.json` lists three MCP
-servers (`chrome-devtools`, `context7`, `grep`). To make them available to
-Codex, ensure `~/.codex/config.toml` contains equivalent entries, e.g.:
+Codex does not read `.mcp.json`. The repo's `.mcp.json` lists four MCP
+servers (`chrome-devtools`, `context7`, `grep`, `estonian`). To make them
+available to Codex, ensure `~/.codex/config.toml` contains equivalent entries,
+e.g.:
 
 ```toml
 [mcp_servers.chrome-devtools]
@@ -68,14 +69,33 @@ url = "https://mcp.context7.com/mcp"
 
 [mcp_servers.grep]
 url = "https://mcp.grep.app"
+
+[mcp_servers.estonian]
+url = "https://estonian-mcp.fly.dev/mcp"
 ```
 
-Read `.mcp.json` as the source of truth and translate it. If a server is
-already present in `config.toml`, leave it. (`url`-based HTTP MCP entries
-require a recent Codex CLI; if yours rejects them, skip context7/grep — they
-are optional conveniences, not required for Phase 2.)
+Read `.mcp.json` as the source of truth and translate it — don't rely on this
+list staying current; if `.mcp.json` has more servers than shown here, port
+those too. If a server is already present in `config.toml`, leave it.
+(`url`-based HTTP MCP entries require a recent Codex CLI; if yours rejects them,
+skip context7/grep/estonian — they are optional conveniences, not required for
+Phase 2.)
 
 ### Non-interactive / test mode
+
+**CI / test environment variables.** These are behavior toggles, not secrets,
+and nothing in the repo loads them from `.env` — the setup scripts read them
+straight from the process environment, and CI sets them via `env:` blocks in
+the workflow files. They have no effect on a normal Claude Code session.
+
+| Variable | Set to | Effect | Used by |
+|----------|--------|--------|---------|
+| `ELNORA_SKIP_OPTIONAL_INSTALLS` | `1` | Skip optional installs (VS Code, Obsidian, etc.) for a lean/headless run | `install-smoke-test.yml`; useful for any headless run |
+| `ELNORA_SKIP_HANDOFF` | `1` | Print the would-be Phase 2 handoff prompt and exit instead of starting an agent session | `install-smoke-test.yml` |
+| `ELNORA_HANDOFF_MODE` | `headless` | Run the Phase 2 handoff non-interactively (`claude -p` / `codex exec`) instead of an interactive session | `handoff-e2e.yml` |
+
+(`ANTHROPIC_API_KEY` — the one genuine secret — is injected into `handoff-e2e`
+from GitHub Secrets, not from `.env`. See `.env.template`.)
 
 If your environment has `ELNORA_HANDOFF_MODE=headless` set, you are running
 inside the `handoff-e2e` test workflow. There is no human to talk to. In that
@@ -213,7 +233,7 @@ mode, follow these adjustments:
 - **Before printing `HANDOFF_COMPLETE`, verify ALL of these are true.** If
   any item is missing, finish it before declaring complete:
   1. `.git/` exists and `git log --oneline | wc -l` is `2` exactly: the
-     initial commit + the step 6 cleanup commit. `1` means cleanup
+     initial commit + the step 8 cleanup commit. `1` means cleanup
      didn't land; anything higher means an unexpected extra commit
      slipped in.
   2. Git remote state depends on which branch of step 3 ran:
@@ -329,7 +349,7 @@ test -f .elnora-handoff-resume.json && echo "RESUME" || echo "FRESH"
      ```
      rm .elnora-handoff-resume.json
      ```
-     This must happen before the step 6 cleanup commit so the marker
+     This must happen before the step 8 cleanup commit so the marker
      doesn't end up in git history.
 
   Steps 4–6 then run as normal.
@@ -985,11 +1005,130 @@ scientist that's usually:
 - "If a web app is misbehaving, I can read the console errors and
   network requests directly instead of asking you to paste them."
 
-### 6. Final cleanup — strip one-shot install scaffolding
+### 6. Vercel CLI + v0 — optional, offer it
+
+The repo already ships the **`vercel` plugin** (bundled and enabled) — so the
+deploy/setup/v0 skills and `/vercel:*` commands are live the moment the user
+trusts the folder. What the user still needs is the **CLI binary** and, for v0,
+an **API key**. Offer to set these up; many hackathon participants will want
+both (and v0 ships with **credits** for them).
+
+> **If you are Codex:** the `vercel` plugin is a Claude Code artifact — the
+> `/vercel:*` slash commands and the deploy/setup/v0 *skills* do not exist for
+> you. Everything below still works; just drive it through the plain CLI and
+> SDK instead of the skill names. Wherever this section says "the `deploy`
+> skill" or `/vercel:deploy`, run `vercel` / `vercel --prod` directly; wherever
+> it says "the `v0` skill" or `/vercel:v0`, call the v0 Platform API via the
+> v0-sdk (or `pnpm create v0-sdk-app@latest`) using `V0_API_KEY` from `.env`.
+> The install steps (CLI binary, login, API key) are identical for both agents.
+
+Don't force it — ask, and only proceed on a yes. If they decline, tell them
+they can later just say "set up Vercel" or "set up v0."
+
+#### 6a. Pre-flight (silent)
+
+```bash
+vercel --version    # already installed?
+node --version      # need Node 18+ for the CLI and v0-sdk
+```
+
+#### 6b. Pitch + ask (read in your own words)
+
+> "I can set up Vercel so I can deploy your apps for you, plus **v0** —
+> Vercel's AI app builder. You've got v0 credits as a hackathon participant, so
+> I can generate and iterate on real UIs from a prompt. Want me to wire it up?"
+
+#### 6c. Install + log in to Vercel
+
+```bash
+npm i -g vercel
+vercel login        # human step: opens a browser / device login
+```
+
+When they have a project to deploy, link it from the project dir:
+```bash
+vercel link         # single project
+# OR
+vercel link --repo  # monorepo
+```
+After that, deploys are just `/vercel:deploy` (the `deploy` skill checks
+prerequisites first). **Production deploys overwrite live URLs — always confirm
+before `vercel --prod`.**
+
+#### 6d. Set up v0
+
+1. Human step: get an API key at <https://v0.app/chat/settings/keys>.
+2. Store it as a secret in `.env` (gitignored) — never in code or chat:
+   ```bash
+   echo 'V0_API_KEY=their-key' >> .env
+   ```
+3. Verify:
+   ```bash
+   curl -s https://api.v0.dev/v1/user -H "Authorization: Bearer $V0_API_KEY" | head
+   ```
+   JSON user object = working. `401` = bad key or billing/credits not enabled.
+4. From here the **`v0` skill** drives it (`/vercel:v0`). Fast path to a new
+   app: `pnpm create v0-sdk-app@latest my-app`. Full reference lives in the
+   skill at `plugins/vercel/skills/v0/SKILL.md`.
+
+If they decline: "No problem — say 'set up Vercel' or 'set up v0' anytime."
+
+### 7. Google Cloud + Vertex AI (image, video, voiceover + more) — optional, offer it
+
+This is the big one. A single one-time setup unlocks Google Cloud's whole AI
+surface: **image generation** (nano-banana), **video** (Veo 3), **voiceover**
+(Text-to-Speech), Gemini text, Imagen, Speech-to-Text, embeddings, translation,
+and more. Offer it — it's a crowd-pleaser at a hackathon — but it's the heaviest
+setup here (two browser logins, a billing-enabled project), so only proceed on a
+yes.
+
+**Your script for this is [`docs/google-cloud-vertex-setup.md`](docs/google-cloud-vertex-setup.md).**
+Follow it top to bottom. It's written for exactly this hand-holding. Key points:
+
+- **You run** the installs and config commands (gcloud install, enable the
+  APIs, set env vars, run the example scripts in `examples/vertex/`).
+- **Only the human can**: create/pick a **billing-enabled GCP project** (and
+  redeem any hackathon GCP credits onto it), and complete the **two browser
+  logins** — `gcloud auth login` and `gcloud auth application-default login`.
+  Never invent a project ID; use the one they give you.
+- Everything uses **their own** GCP project. The kit ships **no** Google
+  credentials and you must never commit any.
+- **This setup is general, not just the three example scripts.** Once ADC is
+  done, you can reach ANY Google Cloud AI API — mint a token with
+  `gcloud auth application-default print-access-token` and call the REST
+  endpoint (the "Call any Google Cloud AI API" recipe in the guide), or use the
+  `google-genai` SDK for Vertex models. If a participant asks for a capability
+  the example scripts don't cover, set it up — don't say it's unsupported.
+
+#### 7a. Pitch + ask (your own words)
+
+> "I can set up Google Cloud so I can generate **images** (nano-banana),
+> **video** (Veo 3), and **voiceover** for you — and from there reach the rest
+> of Google's AI models too. It's a bit more setup — you'll need a Google Cloud
+> project with billing on (your hackathon credits cover the usage), and you'll
+> do two quick browser logins. Want to do it now?"
+
+#### 7b. If yes
+
+Work through `docs/google-cloud-vertex-setup.md`. End state to verify (each
+writes a file into `examples/vertex/out/`):
+```bash
+python3 -m pip install -r examples/vertex/requirements.txt
+python3 examples/vertex/generate_image_nano_banana.py "a watercolor fox reading a book"   # PNG
+python3 examples/vertex/generate_voiceover_tts.py "Welcome to the hackathon."             # MP3 (no pip deps)
+```
+A PNG and an MP3 mean image gen and voiceover both work. Then show them the Veo
+video script (needs a region + GCS bucket — see the guide) and mention they can
+ask for any other Google AI capability.
+
+If they decline: "No problem — say 'set up Google Cloud' or 'set up Vertex'
+whenever you want image, video, or voice generation."
+
+### 8. Final cleanup — strip one-shot install scaffolding
 
 Phase 2 is functionally done. What's left is removing the install-time files
 the user no longer needs so their first repo is clean. **Do this only after
-step 5 has completed** (or the user declined step 5 — either way, all
+steps 5–7 have completed** (or the user declined them — either way, all
 earlier steps must be past tense). If any earlier step is still incomplete,
 finish it first and come back here.
 
@@ -1007,7 +1146,7 @@ finish it first and come back here.
 > last reference was step 5f (Chrome troubleshooting). All are now safely
 > deletable.
 
-#### 6a. Tell the user what you're about to do
+#### 8a. Tell the user what you're about to do
 
 Read this in plain language:
 
@@ -1019,7 +1158,7 @@ Read this in plain language:
 Do **not** ask for permission — this is the documented final step of the
 handoff, not an opt-in. Just announce and proceed.
 
-#### 6b. Delete the one-shot files
+#### 8b. Delete the one-shot files
 
 Run from the repo root:
 
@@ -1065,7 +1204,7 @@ done
 
 Output should be empty. Anything printed is a problem — surface it and stop.
 
-#### 6c. Fix the now-broken references in surviving docs
+#### 8c. Fix the now-broken references in surviving docs
 
 Two surviving files have markdown links that pointed at files we just
 deleted. Fix them with the `Edit` tool (do **not** use `python3 -c`,
@@ -1118,8 +1257,13 @@ what's useful for day-to-day work.
   conversation. Customize freely as your workflow evolves.
 - `.claude/` — Claude Code settings, plugins, and per-user knowledge-base
   config (`knowledge-base.local.md` is gitignored).
-- `.mcp.json` — MCP server configuration (Chrome DevTools, Context7, grep).
-- `docs/` — daily-workflow guide and Chrome DevTools setup notes.
+- `.mcp.json` — MCP server configuration (Chrome DevTools, Context7, grep,
+  Estonian language tools).
+- `plugins/` — bundled local plugins, including `vercel` (deploy + v0).
+- `examples/vertex/` — runnable image (nano-banana), video (Veo 3), and
+  voiceover (TTS) scripts.
+- `docs/` — daily-workflow guide, Chrome DevTools setup, and the Google
+  Cloud + Vertex AI setup guide.
 - `TOOLS.md` — installed plugins and MCP servers.
 - `marketplace-plugins.md` — recommended Claude Code plugins.
 
@@ -1150,7 +1294,7 @@ irm https://raw.githubusercontent.com/Elnora-AI/elnora-ai-agent-hackathon-starte
 MIT (inherited from the starter kit).
 ````
 
-#### 6d. Commit and push the cleanup
+#### 8d. Commit and push the cleanup
 
 ```
 git add -A
@@ -1174,13 +1318,13 @@ If `git push` fails, the local cleanup commit is still good — surface the
 push error and tell the user to retry with `git push origin main`. Do
 **not** roll back the deletions.
 
-> **Headless mode (`ELNORA_HANDOFF_MODE=headless`):** run 6b–6d as
+> **Headless mode (`ELNORA_HANDOFF_MODE=headless`):** run 8b–8d as
 > written, including the `Edit`/`Write` calls. The user-facing
-> announcement in 6a is unnecessary (no human to talk to) — skip the
+> announcement in 8a is unnecessary (no human to talk to) — skip the
 > announcement, do the actions. The cleanup commit is part of the
 > documented expected end state and the test fixture asserts on it.
 
-### 7. Done
+### 9. Done
 
 Tell the user:
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ means trusting those sources.
 
 ## If it stops, just run it again
 
-The script stopped, you closed the terminal, or sign-in didn't go through?
-**Just run it again** with the command below. It resumes right where it left
-off — already-installed tools are skipped in seconds and you land back at the
-step that stopped you. Nothing is lost or repeated.
+Stopped, closed the terminal, or sign-in didn't go through? **Just run it
+again.** It resumes where it left off — already-installed tools are skipped in
+seconds. You'll see `Resuming where a previous run left off` at the top, so you
+know it's continuing, not starting over.
 
 ```bash
 # macOS
@@ -68,22 +68,23 @@ bash setup-mac.sh
 .\setup-windows.ps1
 ```
 
-When it restarts you'll see `Resuming where a previous run left off` at the
-top, so you know it's continuing — not starting over.
+Re-running the install one-liner is safe too: it remembers the workspaces you
+already started and offers to resume one instead of creating a duplicate folder.
 
-**Re-running the install one-liner is safe too.** If you've lost track of the
-folder and re-run the `curl … | bash` (or `irm … | iex`) command from the top,
-it remembers the workspace(s) you already set up and offers to resume one
-instead of quietly creating a second folder — so you won't end up with a pile
-of half-finished copies. Pick the one it lists, or choose "new" if you really
-want a fresh workspace.
+The most common stopping point is the **sign-in** step — make sure your agent
+account is active, then re-run and complete the login when the browser opens.
 
-The most common stopping point is the **Claude sign-in** step. If that's where
-you are, make sure you have an active [Claude Pro/Max](https://claude.com/upgrade)
-account, then re-run and complete the login when the browser opens.
+Want a completely clean run instead? Add `--fresh`:
 
-Want a completely clean run instead? Add `--fresh` to start from scratch:
-`bash setup-mac.sh --fresh` (macOS) or `.\setup-windows.ps1 --fresh` (Windows).
+```bash
+# macOS
+bash setup-mac.sh --fresh
+```
+
+```powershell
+# Windows
+.\setup-windows.ps1 --fresh
+```
 
 ## What happens
 
@@ -107,6 +108,17 @@ Want a completely clean run instead? Add `--fresh` to start from scratch:
 | Git, GitHub CLI | Version control and Phase 2 repo creation. |
 | VS Code | Editor for files your agent produces. |
 | Obsidian | Markdown knowledge-base viewer. |
+
+## What's already wired up
+
+The kit comes pre-connected so these work on first launch:
+
+- **MCP servers:** Chrome DevTools (control a browser), Context7 (live docs),
+  grep (search public GitHub), Estonian (language tools).
+- **Vercel + v0 plugin:** deploy and generate UIs with `/vercel:deploy`,
+  `/vercel:v0`, and more.
+- **Vertex AI examples** in `examples/vertex/`: generate images, video, and
+  voiceover using your own Google Cloud project.
 
 ## Repository layout
 
@@ -179,21 +191,6 @@ Defaults in `.claude/settings.json`:
 - `enableAllProjectMcpServers: true` auto-approves every MCP server in [`.mcp.json`](.mcp.json) (Chrome DevTools, Context7, grep, Estonian) so they're connected and usable on first launch — no per-server approval prompt. Remove this key if you'd rather approve each server manually.
 
 Set values to `false` or `"0"` to disable.
-
-## Need custom integrations?
-
-This kit is the foundation: Claude Code set up and ready to build agents. It
-does not ship with integrations to your specific instruments, LIMS, ELN, or
-internal systems.
-
-We're forward-deployed engineers who build those for biotech, pharma, and
-techbio teams. If you want your agents connected to the tools you actually use
-(instrument data, sample tracking, inventory, internal databases, anything
-else), we'll scope it, build it on top of this repo, and get your first
-agents running in production.
-
-Email [carmen.kivisild@elnora.ai](mailto:carmen.kivisild@elnora.ai) to start
-a conversation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
 # Elnora AI Agent Hackathon Starter Kit
 
-One-command setup that installs and wires together your coding agent — **Claude
-Code or Codex** (your choice) — and the supporting dev tools (Python, Node.js,
-Git, GitHub CLI, VS Code, Obsidian) you need to build AI agents from the
-terminal.
+One command sets up everything you need to build AI agents on your laptop — your
+coding agent (**Claude Code or Codex**, your choice) plus the dev tools that go
+with it: Python, Node.js, Git, VS Code, and Obsidian.
 
-Built for the **Elnora & EFS AI hackathon workshop**: run one command and you're
-at a working agent environment in 15–25 minutes, no setup rabbit holes — so you
-spend the workshop building your agent, not fighting installers.
+Built for the **Elnora AI agent hackathon**: run one command and you have a
+working agent environment in 15–25 minutes — so you spend the time building, not
+installing.
 
 ## Who this is for
 
-**Hackathon participants** who want the fastest path from a fresh laptop to a
-working Claude Code or Codex environment, without chasing installers or learning
-what `brew` is on day one.
-
-Also a useful starting point for anyone bootstrapping a Claude Code or Codex
-project, validating an existing setup, or using this as a template to build
-their own agents and plugins.
+Anyone who wants the fastest path from a fresh laptop to a working Claude Code or
+Codex setup. It also works as a clean starting template for any agent project.
 
 ## Requirements
 
@@ -127,15 +121,20 @@ Want a completely clean run instead? Add `--fresh` to start from scratch:
 ├── marketplace-plugins.md                 # Recommended plugin marketplaces
 ├── install.sh / install.ps1               # Bootstrap entry points
 ├── setup-mac.sh / setup-windows.ps1       # Phase 1 setup scripts
-├── .env.template                          # Environment variable placeholders
-├── .mcp.json                              # MCP server configuration
+├── .env.template                          # API-key placeholders — copy to .env, never edit in place
+├── .mcp.json                              # MCP servers (Chrome DevTools, Context7, grep, Estonian)
 ├── .gitignore
 ├── LICENSE                                # MIT
 ├── .claude/
 │   ├── settings.json                      # Plugins, permissions, env defaults
 │   └── knowledge-base.local.md.template   # Per-user knowledge-base config
+├── plugins/                               # Bundled local plugins (vercel + v0)
+│   └── vercel/
+├── examples/
+│   └── vertex/                            # Runnable image (nano-banana), video (Veo 3) + voiceover scripts
 └── docs/
-    └── getting-started.md                 # Daily-workflow guide + manual fallback
+    ├── getting-started.md                 # Daily-workflow guide + manual fallback
+    └── google-cloud-vertex-setup.md       # gcloud + Vertex AI: image, video, voiceover + more
 ```
 
 ## Post-install
@@ -177,6 +176,7 @@ Defaults in `.claude/settings.json`:
 - `CLAUDE_CODE_NO_FLICKER=1` opts into the [full-screen alt-buffer renderer](https://code.claude.com/docs/en/fullscreen).
 - `autoUpdatesChannel: "latest"` opts into [auto-updates](https://code.claude.com/docs/en/setup#auto-updates) on the `latest` channel. Use `"stable"` for ~1-week-old builds. Ignored for package-manager installs.
 - `remoteControlAtStartup: true` auto-enables [Remote Control](https://code.claude.com/docs/en/remote-control). Sessions are reachable from any device signed into your Claude account; review before enabling on machines that handle proprietary data.
+- `enableAllProjectMcpServers: true` auto-approves every MCP server in [`.mcp.json`](.mcp.json) (Chrome DevTools, Context7, grep, Estonian) so they're connected and usable on first launch — no per-server approval prompt. Remove this key if you'd rather approve each server manually.
 
 Set values to `false` or `"0"` to disable.
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -1,9 +1,15 @@
 # RECOVERY.md — Common Failures and Fixes
 
 If something went wrong during install, find your symptom below. Each fix
-takes 1–5 minutes. If your problem isn't listed, ask Claude or share
-`~/claude-starter-install.log` (macOS) / `%USERPROFILE%\claude-starter-install.log`
-(Windows) with whoever is supporting you.
+takes 1–5 minutes. If your problem isn't listed, ask your agent (Claude Code
+or Codex) or share `~/claude-starter-install.log` (macOS) /
+`%USERPROFILE%\claude-starter-install.log` (Windows) with whoever is supporting
+you.
+
+> Most sections below are written for **Claude Code** because it's the default,
+> but the network, Xcode, GitHub, VS Code, and resume fixes apply to **Codex**
+> users verbatim — substitute `codex` for `claude`. Codex-specific symptoms
+> (sign-in, MCP) are in **section 9**.
 
 ---
 
@@ -265,6 +271,63 @@ Then close every shell and reopen. If the addition disappears in a new
 shell, your machine has a Group Policy revert active — talk to IT or
 keep using the WindowsApps fallback and re-run the installer
 periodically.
+
+---
+
+## 9. "I picked Codex and it won't sign in / has no browser tools"
+
+**Symptom A — sign-in:** `codex` runs but reports it needs a plan, or
+`codex login` opens a browser that never completes.
+
+**Fix:** Codex needs an active **ChatGPT Plus/Pro** plan (or an OpenAI API
+key). Two paths:
+
+- **Plan login:** run `codex login` and complete the browser flow. If the
+  browser doesn't open or your network blocks `chatgpt.com`, switch to a
+  personal Wi-Fi/hotspot (see section 3) and retry.
+- **API key instead:** set `OPENAI_API_KEY` in your environment (or `.env`)
+  and Codex skips the browser login entirely. Get a key at
+  `https://platform.openai.com/api-keys`. Never paste it into a committed
+  file — `.env` is gitignored; `.env.template` is not.
+
+Once `codex` opens normally, re-run the install one-liner — it resumes where
+it left off.
+
+**Symptom B — no MCP / browser tools in Codex:** Codex can't drive the browser
+or reach context7 / grep / the Estonian language tools.
+
+**What happened:** Codex does **not** read the repo's `.mcp.json` (that file is
+Claude Code's). Codex reads `~/.codex/config.toml`, which the installer does
+not write for you.
+
+**Fix:** add the servers from `.mcp.json` to `~/.codex/config.toml`. Ask Codex
+"set up my MCP servers from .mcp.json" and it'll translate them, or add them by
+hand:
+
+```toml
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = ["chrome-devtools-mcp@latest", "--autoConnect"]
+
+[mcp_servers.context7]
+url = "https://mcp.context7.com/mcp"
+
+[mcp_servers.grep]
+url = "https://mcp.grep.app"
+
+[mcp_servers.estonian]
+url = "https://estonian-mcp.fly.dev/mcp"
+```
+
+Then restart `codex`. If it rejects the `url`-based HTTP entries, your Codex
+CLI is too old — update it (`npm install -g @openai/codex`) or drop the HTTP
+servers (they're optional; `chrome-devtools` is the one most steps rely on).
+
+**Symptom C — `/vercel:deploy` or other slash commands do nothing in Codex.**
+Slash commands and skills are Claude Code plugin features; Codex has none.
+Use the underlying CLI directly instead — `vercel` / `vercel --prod` to deploy,
+the v0 SDK (`pnpm create v0-sdk-app@latest`) for v0. See the Codex note in
+`INSTALL_FOR_AGENTS.md` → section 6.
 
 ---
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -15,13 +15,16 @@ here, it isn't wired in by default.
 | Claude Code settings | `.claude/settings.json` | Enabled plugins, marketplaces, permissions, env vars |
 | User overrides | `.claude/settings.local.json` (gitignored) | Per-user local settings |
 | MCP servers | `.mcp.json` | Project-scoped MCP wiring |
+| Bundled plugins | `plugins/` (catalog: `plugins/.claude-plugin/marketplace.json`) | Local plugin marketplace shipped in the repo (currently `vercel`, incl. v0) |
+| Vertex examples | `examples/vertex/` | Runnable image (nano-banana), video (Veo 3) + voiceover (TTS) scripts |
 | Knowledge base | `.claude/knowledge-base.local.md` (gitignored) | Vault path config — read, never hardcode |
 | Project rules | `CLAUDE.md` | Always-loaded context + conventions |
 | Recovery / handoff | `INSTALL_FOR_AGENTS.md`, `RECOVERY.md` | Phase 2 setup + repair flows |
 | CI | `.github/workflows/*.yml` | bootstrap-e2e, handoff-e2e, install-smoke-test, codeql |
 
 No local `hooks/`, `commands/`, `agents/`, or `skills/` directories exist in
-`.claude/`. All slash commands and skills come from plugins.
+`.claude/`. Slash commands and skills come from plugins — including the
+repo-bundled `vercel` plugin under `plugins/`.
 
 ---
 
@@ -35,18 +38,24 @@ From `.claude/settings.json` `enabledPlugins`. Everything else is opt-in via
 | **commit-commands** | claude-code-plugins | `/commit`, `/commit-push-pr`, `/clean_gone` |
 | **context7** | claude-plugins-official | Up-to-date library/framework docs via MCP (same tools as the standalone `context7` MCP server) |
 | **claude-md-management** | claude-plugins-official | `/revise-claude-md` — audit + improve `CLAUDE.md` files |
+| **vercel** | elnora-starter-plugins (local) | Vercel deploy/setup/integration skills + **v0** (AI app builder); `/vercel:deploy`, `/vercel:setup`, `/vercel:logs`, `/vercel:integration`, `/vercel:v0`. Needs the `vercel` CLI + (for v0) a `V0_API_KEY` — see `INSTALL_FOR_AGENTS.md`. |
 
 ---
 
 ## MCP servers (`.mcp.json`)
 
-Project-scoped, loaded for every session in this repo.
+Project-scoped, loaded for every session in this repo. All four are
+auto-approved on first launch via `enableAllProjectMcpServers: true` in
+`.claude/settings.json` — no per-server approval prompt. Verify with
+`claude mcp list` (each should read `Connected`). For Codex, port these into
+`~/.codex/config.toml` (Codex does not read `.mcp.json`).
 
 | Server | Transport | Endpoint | What it provides |
 |--------|-----------|----------|------------------|
 | **context7** | http | `https://mcp.context7.com/mcp` | `query-docs`, `resolve-library-id` — current library/framework docs |
 | **grep** | http | `https://mcp.grep.app` | `searchGitHub` — semantic code search across **public** GitHub repos. **Privacy:** queries are sent to a third-party service; never search proprietary code or secrets. |
 | **chrome-devtools** | stdio (`npx chrome-devtools-mcp@latest --autoConnect`) | local | Take over your real Chrome via CDP — list/create tabs, navigate, screenshot, run JS, read network/console, Lighthouse. Requires Chrome 144+ running. Setup + recipes: [`docs/chrome-devtools-mcp-setup.md`](docs/chrome-devtools-mcp-setup.md). Windows: `setup-windows.ps1` writes a user-level override wrapping `npx` in `cmd /c`. |
+| **estonian** | http | `https://estonian-mcp.fly.dev/mcp` | Estonian language tools — spell check, morphology, synonyms, register. Use for any Estonian writing/proofreading instead of guessing case forms. |
 
 Other plugins (e.g. `playwright`) ship their own MCP servers and only load
 when you enable that plugin via `/plugins`.
@@ -60,13 +69,19 @@ From `extraKnownMarketplaces` in `.claude/settings.json`. Browse with
 
 | Marketplace | Source | autoUpdate | Default-enabled plugins |
 |-------------|--------|------------|-------------------------|
+| **elnora-starter-plugins** | local `directory: ./plugins` | n/a | `vercel` — bundled in the repo; auto-registers when you trust the folder, no clone needed |
 | **claude-code-plugins** | `anthropics/claude-code` | yes | `commit-commands` |
 | **claude-plugins-official** | `anthropics/claude-plugins-official` | yes | `context7`, `claude-md-management` |
 | **anthropic-agent-skills** | `anthropics/skills` | yes | none (recommended: `document-skills`) |
 | **knowledge-work-plugins** | `anthropics/knowledge-work-plugins` | yes | none — sales, finance, legal, HR, marketing, product, support, data, design, bio-research, etc. |
 | **claude-code-workflows** | `wshobson/agents` | yes | none — community workflows (security, docs, analytics, HR/legal) |
+| **claude-for-legal** | `anthropics/claude-for-legal` | yes | none — commercial, privacy, product, corporate, employment, IP legal agents (contracts, NDAs, DPAs) |
+| **claude-for-financial-services** | `anthropics/financial-services` | yes | none — IB, equity research, PE, wealth mgmt, comps/DCF/LBO, earnings, GL reconciliation |
+| **superpowers-marketplace** | `obra/superpowers-marketplace` | yes | none — brainstorming, writing plans, parallel agents, TDD, systematic debugging, git worktrees |
+| **addy-agent-skills** | `addyosmani/agent-skills` | yes | none — a focused set of high-quality agent skills |
 
-See `marketplace-plugins.md` for the full per-marketplace plugin catalog.
+All four above are **registered only** — browse and install via `/plugins`. See
+`marketplace-plugins.md` for the full per-marketplace plugin catalog.
 
 ---
 
@@ -77,7 +92,7 @@ boundary**. It pattern-matches surface form only.
 
 **Allow** (auto-approved, no prompt):
 - Built-ins: `Read`, `Edit`, `Write`, `Glob`, `Grep`, `WebFetch`, `WebSearch`, `Agent`, `NotebookEdit`, `Monitor`, `Bash`
-- MCP: `mcp__context7__*`, `mcp__grep__*`, `mcp__chrome-devtools__*`
+- MCP: `mcp__context7__*`, `mcp__grep__*`, `mcp__chrome-devtools__*`, `mcp__estonian__*`
 
 **Deny** (blocked outright):
 - Force pushes: `git push --force[ *]`, `git push -f[ *]`
@@ -85,6 +100,11 @@ boundary**. It pattern-matches surface form only.
 - `rm -rf *`, `rm -fr *`, `rm -rf /*`, `rm -rf ~/*`, `rm -rf $HOME*`
 - `sudo *`
 - `shutdown*`, `reboot*`, `halt*`
+- Destructive/irreversible Vercel ops: `vercel remove/rm`, `vercel project rm`,
+  `vercel domains rm/buy/move/transfer-in`, `vercel env add/update/rm`,
+  `vercel alias/certs/blob/cache/integration/flags/redirects` removals,
+  `vercel promote/rollback`, and `vercel api` calls with a mutating method
+  (`-X POST/PUT/PATCH/DELETE`). Read-only `vercel` commands are not denied.
 
 ---
 
@@ -102,7 +122,8 @@ Other settings: `autoUpdatesChannel: latest`, `remoteControlAtStartup: true`,
 
 ## Slash commands
 
-All come from enabled plugins — no project-local commands.
+All come from plugins (the bundled `vercel` plugin plus the marketplace ones) —
+no `.claude/`-local commands.
 
 | Command | Source | What it does |
 |---------|--------|--------------|
@@ -110,6 +131,11 @@ All come from enabled plugins — no project-local commands.
 | `/commit-push-pr` | commit-commands | Commit, push, open PR |
 | `/clean_gone` | commit-commands | Prune branches deleted on remote (incl. worktrees) |
 | `/revise-claude-md` | claude-md-management | Audit + update `CLAUDE.md` |
+| `/vercel:deploy` | vercel | Deploy the current project |
+| `/vercel:setup` | vercel | Install Vercel CLI + link project |
+| `/vercel:logs` | vercel | View deployment logs |
+| `/vercel:integration` | vercel | Manage Vercel Marketplace integrations |
+| `/vercel:v0` | vercel | Generate/iterate a UI or app with v0 |
 | `/plugins` | built-in | Browse / install / remove plugins |
 | `/help`, `/clear`, `/config` | built-in | Standard CLI |
 
@@ -122,6 +148,10 @@ them when a user message matches.
 
 `claude-md-management` exposes a `claude-md-improver` skill alongside its
 slash command.
+
+The bundled `vercel` plugin adds: `vercel` (CLI reference + decision tree),
+`deploy`, `setup`, `integration`, and `v0` (build/iterate UIs via the v0
+Platform API). These fire on Vercel/v0-specific phrasing, not generic words.
 
 ---
 
@@ -158,6 +188,22 @@ Not invokable from chat, but agents may need to know they exist.
 | `.github/scripts/lint-ascii.py` | Enforce ASCII-only in shipped scripts |
 | `tests/handoff/` | Handoff flow fixtures |
 | `cache/` | Runtime scratch (gitignored except `README.md`) |
+| `plugins/vercel/` | Bundled Vercel + v0 plugin (skills, commands, references) |
+| `examples/vertex/` | Runnable image + video + voiceover scripts (`out/` gitignored) |
+
+---
+
+## External CLIs / cloud (agent-assisted setup)
+
+Not wired in by default — the binary/credentials are installed per-user via
+`INSTALL_FOR_AGENTS.md` (optional steps). Once set up, the bundled plugin and
+example scripts use them.
+
+| Tool | What it's for | Setup |
+|------|---------------|-------|
+| **Vercel CLI** (`vercel`) | Deploy/manage projects | `npm i -g vercel` + `vercel login`; `INSTALL_FOR_AGENTS.md` step 6 |
+| **v0** (Vercel AI app builder) | Generate UIs/apps; hackathon **credits** | `V0_API_KEY` in `.env`; `v0` skill / `INSTALL_FOR_AGENTS.md` step 6 |
+| **gcloud + Vertex AI** | Image (nano-banana), video (Veo 3), voiceover (TTS) — and any Google Cloud AI API via the ADC-token recipe | [`docs/google-cloud-vertex-setup.md`](docs/google-cloud-vertex-setup.md); `INSTALL_FOR_AGENTS.md` step 7. Uses the user's **own** GCP project — no committed credentials. |
 
 ---
 
@@ -174,4 +220,4 @@ Not invokable from chat, but agents may need to know they exist.
 
 ---
 
-_Last updated: 2026-04-28_
+_Last updated: 2026-06-10_

--- a/docs/google-cloud-vertex-setup.md
+++ b/docs/google-cloud-vertex-setup.md
@@ -1,0 +1,252 @@
+# Google Cloud + Vertex AI setup (image, video, voiceover + the rest)
+
+**Set this up once and you unlock Google Cloud's whole AI surface** — image
+generation (Gemini 2.5 Flash Image, a.k.a. "nano-banana"), video (Veo 3),
+voiceover (Text-to-Speech), Gemini text, Imagen, Speech-to-Text, embeddings,
+translation, and more. It's all the **same one-time auth** (`gcloud` +
+Application Default Credentials); after that, every model is a different
+endpoint or model ID, not a new setup.
+
+The auth pattern here — ADC plus a short-lived access token — is the standard,
+Google-documented way to call these APIs; nothing in this repo is specific to
+any one account.
+
+> **For agents:** this is a hand-holding guide. The human almost certainly has
+> never touched `gcloud`. Run each command *for* them where you can, read back
+> the output, and stop at the two steps only they can do (creating/picking a
+> billing-enabled project, and the browser auth). Never invent a project ID —
+> use the one they give you. Everything here uses **their own** GCP project; the
+> starter kit ships no Google credentials. Once §3 (ADC) is done, you can reach
+> **any** Google Cloud AI API with the universal recipe below — you are not
+> limited to the example scripts.
+
+---
+
+## What you can do once this works
+
+| Capability | Model / endpoint | How |
+|------------|------------------|-----|
+| Image generation + editing ("nano-banana") | `gemini-2.5-flash-image` | SDK — [`examples/vertex/generate_image_nano_banana.py`](../examples/vertex/generate_image_nano_banana.py) |
+| Text/image → video ("Veo 3") | `veo-3.0-generate-001` | SDK — [`examples/vertex/generate_video_veo.py`](../examples/vertex/generate_video_veo.py) |
+| Voiceover / narration (Text-to-Speech) | `texttospeech.googleapis.com` | REST + ADC token — [`examples/vertex/generate_voiceover_tts.py`](../examples/vertex/generate_voiceover_tts.py) |
+| Gemini text / chat / vision | `gemini-2.5-flash`, `gemini-2.5-pro` | SDK `client.models.generate_content` |
+| Imagen (photoreal images) | `imagen-4.0-generate-001` | SDK `client.models.generate_images` |
+| Speech-to-Text (transcription) | `speech.googleapis.com` | REST + ADC token (same recipe as TTS) |
+| Text embeddings | `text-embedding-005` | SDK `client.models.embed_content` |
+| Translation | `translate.googleapis.com` | REST + ADC token |
+
+The example scripts cover the first three. Everything else is reachable with the
+**universal recipe** (see "Call any Google Cloud AI API" below) — Vertex/Google
+Cloud is a large catalogue and the same credentials open all of it.
+
+---
+
+## Prerequisites (human does these)
+
+1. **A Google account** and access to <https://console.cloud.google.com>.
+2. **A Google Cloud project with billing enabled.** Vertex AI will not run
+   without a billing account attached, even when you're spending free credits.
+   - New project: <https://console.cloud.google.com/projectcreate>
+   - Note the **Project ID** (not the display name) — e.g. `my-hackathon-1234`.
+   - Hackathon participants: if you were given GCP credits, redeem them and
+     attach the billing account to this project.
+
+Give the agent your **Project ID** when asked.
+
+---
+
+## Step 1 — Install the gcloud CLI
+
+The agent can run these. Verify first: `gcloud --version`.
+
+**macOS** (Homebrew is cleanest):
+```bash
+brew install --cask google-cloud-sdk
+```
+No Homebrew? Use the interactive installer:
+```bash
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL    # reload shell so `gcloud` is on PATH
+```
+
+**Windows (PowerShell):**
+```powershell
+(New-Object Net.WebClient).DownloadFile("https://dl.google.com/dl/cloudsdk/channels/rapid/GoogleCloudSDKInstaller.exe", "$env:Temp\GoogleCloudSDKInstaller.exe")
+& "$env:Temp\GoogleCloudSDKInstaller.exe"
+```
+
+**Linux:**
+```bash
+curl https://sdk.cloud.google.com | bash && exec -l $SHELL
+```
+
+Confirm:
+```bash
+gcloud --version
+```
+
+---
+
+## Step 2 — Log in and select the project
+
+**Human step (browser):** authenticate the CLI.
+```bash
+gcloud auth login
+```
+
+Point gcloud at the project (use the Project ID from prerequisites):
+```bash
+gcloud config set project YOUR_PROJECT_ID
+```
+
+---
+
+## Step 3 — Application Default Credentials (ADC)
+
+The SDK authenticates via ADC, *not* the `gcloud auth login` session above.
+This is a second browser login — it's expected.
+
+**Human step (browser):**
+```bash
+gcloud auth application-default login
+```
+
+Set the quota/billing project for ADC so the SDK knows who to bill:
+```bash
+gcloud auth application-default set-quota-project YOUR_PROJECT_ID
+```
+
+> Service-account JSON key files also work (set `GOOGLE_APPLICATION_CREDENTIALS`
+> to the file path), but for a laptop, ADC via browser login is simpler and
+> there's no key file to leak. Prefer ADC unless you're deploying to a server.
+
+---
+
+## Step 4 — Enable the APIs you want
+
+Vertex AI (image, video, Gemini, Imagen, embeddings) is one API. Voiceover,
+transcription, and translation are separate APIs — enable whichever you'll use.
+Enabling one you don't end up calling costs nothing.
+
+```bash
+# Vertex AI — image (nano-banana), video (Veo), Gemini, Imagen, embeddings
+gcloud services enable aiplatform.googleapis.com --project YOUR_PROJECT_ID
+
+# Voiceover (Text-to-Speech) — used by the voiceover example
+gcloud services enable texttospeech.googleapis.com --project YOUR_PROJECT_ID
+
+# Optional extras — enable on demand
+gcloud services enable speech.googleapis.com     --project YOUR_PROJECT_ID  # speech-to-text
+gcloud services enable translate.googleapis.com  --project YOUR_PROJECT_ID  # translation
+```
+
+Each can take a minute the first time.
+
+---
+
+## Step 5 — Environment variables
+
+Copy these into your `.env` (already scaffolded in `.env.template`), or export
+them in the shell. The example scripts read them.
+
+```bash
+export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID
+export GOOGLE_CLOUD_LOCATION=global      # Gemini/nano-banana; Veo needs a region (see below)
+export GOOGLE_GENAI_USE_VERTEXAI=True
+```
+
+- **nano-banana (image):** `global` is fine.
+- **Veo 3 (video):** use a regional location such as `us-central1`, and provide
+  a **GCS bucket** for the output:
+  ```bash
+  export GOOGLE_CLOUD_LOCATION=us-central1
+  export VERTEX_OUTPUT_GCS_URI=gs://your-bucket/veo
+  # one-time: create the bucket
+  gcloud storage buckets create gs://your-bucket --location=us-central1
+  ```
+
+---
+
+## Step 6 — Install the SDK and run the examples
+
+```bash
+python3 -m pip install -r examples/vertex/requirements.txt
+
+# image (nano-banana)
+python3 examples/vertex/generate_image_nano_banana.py "a watercolor fox reading a book"
+
+# video (Veo 3) — needs GOOGLE_CLOUD_LOCATION=us-central1 + VERTEX_OUTPUT_GCS_URI
+python3 examples/vertex/generate_video_veo.py "a timelapse of a city at dusk"
+
+# voiceover (Text-to-Speech) — needs texttospeech.googleapis.com enabled (Step 4)
+python3 examples/vertex/generate_voiceover_tts.py "Welcome to the hackathon."
+```
+
+A PNG, an MP4 (Veo), and an MP3 (voiceover) land in `examples/vertex/out/`. The
+voiceover script uses only the Python standard library — no pip install needed
+for that one.
+
+---
+
+## Call any Google Cloud AI API (the universal recipe)
+
+The example scripts are starting points, not the boundary. Once Step 3 (ADC) is
+done, **any** Google Cloud REST API is reachable with a short-lived access token
+— this is exactly how the voiceover example works, and it generalizes to
+Speech-to-Text, Translation, Document AI, and the rest.
+
+```bash
+# A token good for ~1 hour, minted from your ADC login:
+TOKEN=$(gcloud auth application-default print-access-token)
+
+# Then call any API: Bearer token + your project as the quota header.
+curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "x-goog-user-project: YOUR_PROJECT_ID" \
+  -H "Content-Type: application/json" \
+  "https://texttospeech.googleapis.com/v1/text:synthesize" \
+  -d '{
+        "input": {"text": "Hello from Google Cloud"},
+        "voice": {"languageCode": "en-US", "name": "en-US-Neural2-F"},
+        "audioConfig": {"audioEncoding": "MP3"}
+      }'
+```
+
+The two load-bearing headers for any Google Cloud API are the **Bearer token**
+and **`x-goog-user-project`** (which project gets billed/quota'd). Swap the URL
+and JSON body for whatever service you need — the
+[API reference](https://cloud.google.com/apis) lists endpoints for every
+service. For Vertex AI specifically, the `google-genai` SDK (used by the image
+and video examples) is usually nicer than raw REST, but the token recipe always
+works as a fallback.
+
+> **For agents:** when a participant wants a Google Cloud capability the example
+> scripts don't cover, don't tell them it's unsupported — mint a token with the
+> command above and call the right REST endpoint, or use the `google-genai` SDK
+> for Vertex models. The setup is identical; only the endpoint changes.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `PermissionDenied` / `aiplatform.googleapis.com ... not enabled` | Re-run Step 4; wait a minute; confirm the right project with `gcloud config get-value project`. |
+| `Reauthentication required` / `invalid_grant` | Re-run `gcloud auth application-default login`. |
+| `403 ... billing` | Attach a billing account to the project in the console. |
+| Veo: `output_gcs_uri` error or empty result | Veo writes to GCS. Set `VERTEX_OUTPUT_GCS_URI` and use a regional `GOOGLE_CLOUD_LOCATION` (e.g. `us-central1`). |
+| Voiceover: `texttospeech ... not enabled` / `403` | Enable it: `gcloud services enable texttospeech.googleapis.com`. |
+| Voiceover: `SERVICE_DISABLED` for `x-goog-user-project` | The project in the header must match a real, billing-enabled project you own. |
+| Model `not found` / `404` | Model IDs evolve. Check current IDs in [Model Garden](https://console.cloud.google.com/vertex-ai/model-garden); newer variants (e.g. `veo-3.1-generate-001`, Gemini 3 image) may be available. |
+| Quota exceeded | These are preview models with low default quotas — request more in the console or retry later. |
+
+## Security notes
+
+- The example scripts never write secrets. ADC tokens live in
+  `~/.config/gcloud/` (managed by gcloud), not in this repo.
+- If you use a service-account key, keep the `.json` out of git (the repo's
+  `.gitignore` already covers `credentials*.json` / `*.json` keys — verify
+  before committing) and reference it only by path via
+  `GOOGLE_APPLICATION_CREDENTIALS`.
+- All nano-banana output carries an invisible **SynthID** watermark marking it
+  AI-generated.

--- a/examples/vertex/README.md
+++ b/examples/vertex/README.md
@@ -1,0 +1,45 @@
+# Google Cloud AI examples — image, video, voiceover
+
+Minimal, runnable scripts. The image and video ones use the `google-genai` SDK
+(Vertex AI); the voiceover one uses the standard-library "ADC token + REST"
+pattern (no pip deps) that works for **any** Google Cloud API.
+
+| Script | What it does | Model / endpoint | Deps |
+|--------|--------------|------------------|------|
+| `generate_image_nano_banana.py` | Text → image (and editing) | `gemini-2.5-flash-image` | `google-genai` |
+| `generate_video_veo.py` | Text → video | `veo-3.0-generate-001` | `google-genai` |
+| `generate_voiceover_tts.py` | Text → narration (MP3) | `texttospeech.googleapis.com` | stdlib only |
+
+These three are starting points, not the limit. The same one-time setup unlocks
+Gemini text, Imagen, Speech-to-Text, embeddings, translation, and more — see the
+"Call any Google Cloud AI API" recipe in
+[`../../docs/google-cloud-vertex-setup.md`](../../docs/google-cloud-vertex-setup.md).
+
+## Quick start
+
+1. Do the one-time setup in [`../../docs/google-cloud-vertex-setup.md`](../../docs/google-cloud-vertex-setup.md)
+   (install gcloud, `application-default login`, enable Vertex AI, set env vars).
+   **New to this? Ask the agent** — it can run most of it for you.
+2. Install deps:
+   ```bash
+   python3 -m pip install -r requirements.txt
+   ```
+3. Generate:
+   ```bash
+   python3 generate_image_nano_banana.py "a watercolor fox reading a book"
+   python3 generate_video_veo.py "a timelapse of a city at dusk"
+   python3 generate_voiceover_tts.py "Welcome to the hackathon."
+   ```
+
+Output lands in `out/` (gitignored). Image gen needs `GOOGLE_CLOUD_LOCATION=global`;
+Veo needs a region (`us-central1`) plus a `VERTEX_OUTPUT_GCS_URI` bucket;
+voiceover needs `texttospeech.googleapis.com` enabled and only
+`GOOGLE_CLOUD_PROJECT` set.
+
+## Notes
+
+- These use **your own** GCP project. Nothing here ships Google credentials.
+- Model IDs change. If you hit a `404`, check
+  [Model Garden](https://console.cloud.google.com/vertex-ai/model-garden) for
+  the current ID (e.g. `veo-3.1-generate-001`).
+- nano-banana images carry an invisible SynthID watermark.

--- a/examples/vertex/generate_image_nano_banana.py
+++ b/examples/vertex/generate_image_nano_banana.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Generate an image with Gemini 2.5 Flash Image ("nano-banana") on Vertex AI.
+
+Usage:
+    python3 generate_image_nano_banana.py "a watercolor fox reading a book"
+
+Auth/config comes entirely from environment variables (see
+docs/google-cloud-vertex-setup.md):
+    GOOGLE_GENAI_USE_VERTEXAI=True
+    GOOGLE_CLOUD_PROJECT=<your-project-id>
+    GOOGLE_CLOUD_LOCATION=global
+
+Run `gcloud auth application-default login` first so the SDK has credentials.
+The script writes nothing sensitive and stores no keys.
+"""
+import os
+import sys
+from pathlib import Path
+
+MODEL = "gemini-2.5-flash-image"  # "nano-banana"
+OUT_DIR = Path(__file__).parent / "out"
+
+
+def main() -> int:
+    prompt = " ".join(sys.argv[1:]).strip() or "a friendly robot watering a plant, soft studio lighting"
+
+    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() != "true":
+        print("Set GOOGLE_GENAI_USE_VERTEXAI=True (see docs/google-cloud-vertex-setup.md).", file=sys.stderr)
+        return 2
+    if not os.environ.get("GOOGLE_CLOUD_PROJECT"):
+        print("Set GOOGLE_CLOUD_PROJECT to your own GCP project ID.", file=sys.stderr)
+        return 2
+
+    try:
+        from google import genai
+    except ImportError:
+        print("Missing dependency. Run: pip install -r examples/vertex/requirements.txt", file=sys.stderr)
+        return 2
+
+    # Reads GOOGLE_CLOUD_PROJECT / GOOGLE_CLOUD_LOCATION / GOOGLE_GENAI_USE_VERTEXAI from env.
+    client = genai.Client()
+
+    print(f"Generating with {MODEL} ...\n  prompt: {prompt}")
+    try:
+        response = client.models.generate_content(model=MODEL, contents=prompt)
+    except Exception as exc:  # noqa: BLE001 — surface the real cause to the user
+        print(f"\nGeneration failed: {exc}\n", file=sys.stderr)
+        print("Common fixes: enable Vertex AI (gcloud services enable aiplatform.googleapis.com),", file=sys.stderr)
+        print("re-run `gcloud auth application-default login`, confirm billing is attached.", file=sys.stderr)
+        return 1
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    saved = 0
+    for candidate in response.candidates or []:
+        for part in (candidate.content.parts or []):
+            inline = getattr(part, "inline_data", None)
+            if inline and inline.data:
+                saved += 1
+                ext = "png"
+                if inline.mime_type and "/" in inline.mime_type:
+                    ext = inline.mime_type.split("/")[-1]
+                out = OUT_DIR / f"nano_banana_{saved}.{ext}"
+                out.write_bytes(inline.data)
+                print(f"  saved {out}  ({len(inline.data):,} bytes)")
+            elif getattr(part, "text", None):
+                print(f"  model note: {part.text}")
+
+    if not saved:
+        print("\nNo image returned. The model may have refused the prompt — try rephrasing.", file=sys.stderr)
+        return 1
+    print(f"\nDone. {saved} image(s) in {OUT_DIR}/")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vertex/generate_video_veo.py
+++ b/examples/vertex/generate_video_veo.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Generate a video with Veo 3 on Vertex AI.
+
+Usage:
+    python3 generate_video_veo.py "a timelapse of a city at dusk"
+
+Veo on Vertex writes the rendered MP4 to a Google Cloud Storage bucket, so this
+needs a REGIONAL location and an output bucket (see docs/google-cloud-vertex-setup.md):
+    GOOGLE_GENAI_USE_VERTEXAI=True
+    GOOGLE_CLOUD_PROJECT=<your-project-id>
+    GOOGLE_CLOUD_LOCATION=us-central1
+    VERTEX_OUTPUT_GCS_URI=gs://your-bucket/veo
+
+The script writes nothing sensitive and stores no keys. Generation takes a few
+minutes — that's normal for video.
+"""
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+MODEL = "veo-3.0-generate-001"  # "Veo 3"; newer: veo-3.1-generate-001
+OUT_DIR = Path(__file__).parent / "out"
+POLL_SECONDS = 15
+
+
+def main() -> int:
+    prompt = " ".join(sys.argv[1:]).strip() or "a slow cinematic pan over snow-capped mountains at sunrise"
+
+    if os.environ.get("GOOGLE_GENAI_USE_VERTEXAI", "").lower() != "true":
+        print("Set GOOGLE_GENAI_USE_VERTEXAI=True (see docs/google-cloud-vertex-setup.md).", file=sys.stderr)
+        return 2
+    if not os.environ.get("GOOGLE_CLOUD_PROJECT"):
+        print("Set GOOGLE_CLOUD_PROJECT to your own GCP project ID.", file=sys.stderr)
+        return 2
+    gcs_uri = os.environ.get("VERTEX_OUTPUT_GCS_URI")
+    if not gcs_uri:
+        print("Veo writes to GCS. Set VERTEX_OUTPUT_GCS_URI=gs://your-bucket/veo", file=sys.stderr)
+        print("and GOOGLE_CLOUD_LOCATION to a region like us-central1.", file=sys.stderr)
+        return 2
+
+    try:
+        from google import genai
+        from google.genai.types import GenerateVideosConfig
+    except ImportError:
+        print("Missing dependency. Run: pip install -r examples/vertex/requirements.txt", file=sys.stderr)
+        return 2
+
+    client = genai.Client()  # reads project/location/Vertex flag from env
+
+    print(f"Generating with {MODEL} ...\n  prompt: {prompt}\n  output: {gcs_uri}")
+    try:
+        operation = client.models.generate_videos(
+            model=MODEL,
+            prompt=prompt,
+            config=GenerateVideosConfig(aspect_ratio="16:9", output_gcs_uri=gcs_uri),
+        )
+        waited = 0
+        while not operation.done:
+            time.sleep(POLL_SECONDS)
+            waited += POLL_SECONDS
+            print(f"  ... still rendering ({waited}s)")
+            operation = client.operations.get(operation)
+    except Exception as exc:  # noqa: BLE001
+        print(f"\nGeneration failed: {exc}\n", file=sys.stderr)
+        print("Common fixes: enable Vertex AI, use a regional location (us-central1),", file=sys.stderr)
+        print("ensure the GCS bucket exists and billing is attached.", file=sys.stderr)
+        return 1
+
+    videos = getattr(operation.result, "generated_videos", None) or []
+    if not videos:
+        print("\nNo video returned — the prompt may have been refused. Try rephrasing.", file=sys.stderr)
+        return 1
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    for i, gv in enumerate(videos, start=1):
+        uri = getattr(getattr(gv, "video", None), "uri", None)
+        print(f"  video {i}: {uri}")
+        if uri and uri.startswith("gs://"):
+            local = OUT_DIR / f"veo_{i}.mp4"
+            # Best-effort local copy; ignore if gcloud/gsutil isn't on PATH.
+            try:
+                subprocess.run(["gcloud", "storage", "cp", uri, str(local)], check=True)
+                print(f"    copied to {local}")
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                print(f"    (couldn't copy locally — fetch it with: gcloud storage cp {uri} {local})")
+
+    print(f"\nDone. Video(s) in {gcs_uri} (and {OUT_DIR}/ if the copy succeeded).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vertex/generate_voiceover_tts.py
+++ b/examples/vertex/generate_voiceover_tts.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Generate a voiceover (MP3) with Google Cloud Text-to-Speech.
+
+Usage:
+    python3 generate_voiceover_tts.py "Welcome to the hackathon."
+    python3 generate_voiceover_tts.py "Tere tulemast" --language et-EE --voice et-EE-Standard-A
+
+This is the universal "ADC token + REST" pattern from the setup guide, so it
+needs NO pip dependencies — just the Python standard library plus the `gcloud`
+CLI for the access token. The same shape calls any Google Cloud REST API.
+
+Setup (see docs/google-cloud-vertex-setup.md):
+    gcloud auth application-default login
+    gcloud services enable texttospeech.googleapis.com --project YOUR_PROJECT_ID
+    export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_ID
+
+Pick a voice/language from https://cloud.google.com/text-to-speech/docs/voices
+(default: en-US-Neural2-F). Writes nothing sensitive and stores no keys.
+"""
+import argparse
+import base64
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ENDPOINT = "https://texttospeech.googleapis.com/v1/text:synthesize"
+OUT_DIR = Path(__file__).parent / "out"
+
+
+def access_token() -> str:
+    """Short-lived token minted from the user's ADC login."""
+    return subprocess.run(
+        ["gcloud", "auth", "application-default", "print-access-token"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Google Cloud Text-to-Speech voiceover")
+    parser.add_argument("text", nargs="*", help="Text to narrate")
+    parser.add_argument("--language", default="en-US", help="BCP-47 code, e.g. en-US, et-EE")
+    parser.add_argument("--voice", default="en-US-Neural2-F", help="Voice name")
+    parser.add_argument("--rate", type=float, default=1.0, help="Speaking rate (0.25–4.0)")
+    args = parser.parse_args()
+
+    text = " ".join(args.text).strip() or "Welcome to the hackathon. Let's build something."
+    project = os.environ.get("GOOGLE_CLOUD_PROJECT")
+    if not project:
+        print("Set GOOGLE_CLOUD_PROJECT to your own GCP project ID.", file=sys.stderr)
+        return 2
+
+    try:
+        token = access_token()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("Couldn't get a token. Run: gcloud auth application-default login", file=sys.stderr)
+        print("(and install the gcloud CLI — see docs/google-cloud-vertex-setup.md)", file=sys.stderr)
+        return 2
+
+    body = json.dumps({
+        "input": {"text": text},
+        "voice": {"languageCode": args.language, "name": args.voice},
+        "audioConfig": {"audioEncoding": "MP3", "speakingRate": args.rate},
+    }).encode()
+
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-goog-user-project": project,  # which project gets billed/quota'd
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    print(f"Synthesizing ({args.voice}, {args.language}) ...\n  text: {text}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode(errors="replace")[:500]
+        print(f"\nTTS failed ({exc.code}): {detail}\n", file=sys.stderr)
+        print("Common fixes: enable texttospeech.googleapis.com, confirm the voice name", file=sys.stderr)
+        print("exists for the language, and that billing is attached to the project.", file=sys.stderr)
+        return 1
+
+    audio_b64 = data.get("audioContent")
+    if not audio_b64:
+        print("No audioContent in response.", file=sys.stderr)
+        return 1
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out = OUT_DIR / "voiceover.mp3"
+    out.write_bytes(base64.b64decode(audio_b64))
+    print(f"\nDone. {out} ({out.stat().st_size:,} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vertex/out/.gitignore
+++ b/examples/vertex/out/.gitignore
@@ -1,0 +1,3 @@
+# Generated media — never commit
+*
+!.gitignore

--- a/examples/vertex/requirements.txt
+++ b/examples/vertex/requirements.txt
@@ -1,0 +1,5 @@
+# Vertex AI generative examples (nano-banana image, Veo 3 video).
+# Install: python3 -m pip install -r examples/vertex/requirements.txt
+# Note: the voiceover example (generate_voiceover_tts.py) needs NONE of this —
+# it uses only the Python standard library + the gcloud CLI.
+google-genai>=1.0.0

--- a/marketplace-plugins.md
+++ b/marketplace-plugins.md
@@ -112,24 +112,66 @@ See the full list of 40+ plugins on [github.com/anthropics/knowledge-work-plugin
 
 The marketplace has 15+ plugins total; browse the rest via `/plugins`.
 
----
+### 6. Claude for Legal (`claude-for-legal`)
 
-## Other Marketplaces (add later)
+**Source**: github.com/anthropics/claude-for-legal
+**Trust level**: High — official Anthropic legal marketplace
+**Status**: Registered, **no plugins enabled by default** — browse and install what you need via `/plugins`.
 
-These are community-maintained. Quality is generally good but not Anthropic-verified.
-You can add them via `/plugins` > "Add marketplace" when you're ready.
+In-house legal agents for contracts, NDAs, and DPAs.
 
-### Superpowers — alternate source (`superpowers-marketplace`)
+| Plugin | What it gives you | Best for |
+|--------|-------------------|----------|
+| **commercial-legal** | Vendor/MSA/SaaS review, NDA triage, playbook deviations, renewals | Commercial contracts |
+| **privacy-legal** | DPA review, PIAs, DSAR responses, reg gap analysis | Privacy / data protection |
+| **product-legal** | Launch review, marketing-claims review, feature risk | Product counsel |
+| **corporate-legal** | M&A diligence, board minutes, written consents, entity compliance | Corporate / secretary |
+| **employment-legal** | Offer/termination review, leave tracking, investigations | Employment / HR legal |
+| **ip-legal** | IP-focused agents and skills | Patents / IP |
+
+The marketplace has more (regulatory, AI governance, litigation, legal clinic, etc.); browse via `/plugins`.
+
+### 7. Claude for Financial Services (`claude-for-financial-services`)
+
+**Source**: github.com/anthropics/financial-services
+**Trust level**: High — official Anthropic financial-services marketplace
+**Status**: Registered, **no plugins enabled by default** — browse and install what you need via `/plugins`.
+
+Reference agents and skills for IB, equity research, PE, and wealth management — comps, DCF, LBO, earnings, GL reconciliation.
+
+| Plugin | What it gives you | Best for |
+|--------|-------------------|----------|
+| **investment-banking** | Comps, DCF, LBO, pitch support | IB / M&A advisory |
+| **equity-research** | Earnings reviews, model building, valuation | Research analysts |
+| **private-equity** | Deal screening, diligence, valuation review | PE / buyside |
+| **wealth-management** | Client prep, portfolio workflows | Wealth / advisory |
+| **gl-reconciler** | GL reconciliation, month-end close, statement audit | Finance / accounting |
+| **fund-admin** | Fund administration workflows | Fund ops |
+
+20+ plugins total (plus partner data connectors like LSEG and S&P Global); browse via `/plugins`.
+
+### 8. Superpowers (`superpowers-marketplace`)
 
 **Source**: github.com/obra/superpowers-marketplace
-**What's in it**: Advanced workflow skills — brainstorming, TDD, systematic debugging, parallel agent dispatch. Best for power users.
+**Trust level**: Medium — community-maintained (Jesse Vincent / obra), not Anthropic-verified
+**Status**: Registered, **no plugins enabled by default** — browse and install what you need via `/plugins`.
 
-> **Note**: `superpowers` is **not** enabled by default in `.claude/settings.json`
-> — only `commit-commands`, `context7`, and `claude-md-management` are.
-> Two ways to add it: install from the Anthropic-maintained
-> `claude-plugins-official` marketplace (already registered in
-> `extraKnownMarketplaces`, just enable via `/plugins`), or add the
-> community-maintained `obra/superpowers-marketplace` source for obra's variant.
+Advanced workflow skills for power users — brainstorming, writing plans, parallel agent dispatch, TDD, systematic debugging, git worktrees.
+
+> A related `superpowers` plugin is also available in the Anthropic-maintained
+> `claude-plugins-official` marketplace — either source works; enable via `/plugins`.
+
+### 9. Addy Osmani Agent Skills (`addy-agent-skills`)
+
+**Source**: github.com/addyosmani/agent-skills
+**Trust level**: Medium — community-maintained (Addy Osmani), not Anthropic-verified
+**Status**: Registered, **no plugins enabled by default** — browse and install what you need via `/plugins`.
+
+A focused set of high-quality agent skills.
+
+| Plugin | What it gives you | Best for |
+|--------|-------------------|----------|
+| **agent-skills** | Addy Osmani's curated agent-skill collection | Anyone wanting a small, high-signal skill set |
 
 ---
 

--- a/plugins/.claude-plugin/marketplace.json
+++ b/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "elnora-starter-plugins",
+  "description": "Plugins bundled with the Elnora AI agent hackathon starter kit. Cloning the repo ships these locally — no external marketplace needed.",
+  "version": "1.0.0",
+  "owner": {
+    "name": "Elnora AI",
+    "email": "support@elnora.ai"
+  },
+  "plugins": [
+    {
+      "name": "vercel",
+      "version": "1.1.0",
+      "description": "Vercel platform management plus v0 — deploy, configure, monitor, and debug projects, and build UIs/apps with the v0 Platform API. Use when: deploy, vercel, v0, preview, production, logs, domains, environment variables, cron jobs.",
+      "source": "./vercel"
+    }
+  ]
+}

--- a/plugins/vercel/.claude-plugin/plugin.json
+++ b/plugins/vercel/.claude-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "vercel",
+  "version": "1.1.0",
+  "description": "Vercel platform management plus v0 — deploy, configure, monitor, and debug projects, and build UIs/apps with the v0 Platform API. Use when: deploy, vercel, v0, preview, production, logs, domains, environment variables, cron jobs.",
+  "author": {
+    "name": "Elnora AI",
+    "email": "support@elnora.ai"
+  },
+  "keywords": [
+    "vercel", "v0", "deploy", "hosting", "serverless", "domains",
+    "environment-variables", "logs", "cron", "next.js"
+  ]
+}

--- a/plugins/vercel/README.md
+++ b/plugins/vercel/README.md
@@ -1,0 +1,30 @@
+# Vercel Plugin
+
+Vercel platform management — deploy, configure, monitor, and debug projects
+from the CLI, plus **v0** (Vercel's AI app builder) via its Platform API.
+
+## Skills
+
+| Skill | Trigger | Description |
+|-------|---------|-------------|
+| `vercel` | vercel, CLI reference, domains, env vars | Main routing skill with decision tree and full CLI reference |
+| `deploy` | deploy, preview, production | Deploy workflow with prerequisites check |
+| `setup` | setup, link, install vercel | First-time project setup and linking |
+| `integration` | marketplace integrations, databases, auth | Discover/install/configure Vercel Marketplace integrations |
+| `v0` | v0, generate UI, v0 API/SDK, v0 credits | Build/iterate UIs and apps with the v0 Platform API |
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `/vercel:deploy` | Deploy the current project |
+| `/vercel:setup` | Set up Vercel CLI and link project |
+| `/vercel:logs` | View deployment logs |
+| `/vercel:integration` | Manage Vercel Marketplace integrations |
+| `/vercel:v0` | Generate or iterate on a UI/app with v0 |
+
+## References
+
+The `skills/vercel/references/` directory contains 17 detailed reference files
+covering all Vercel CLI topics. The main skill's decision tree routes to the
+appropriate reference based on the task.

--- a/plugins/vercel/commands/deploy.md
+++ b/plugins/vercel/commands/deploy.md
@@ -1,0 +1,8 @@
+---
+name: deploy
+description: Deploy the current project to Vercel
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+Invoke the `deploy` skill from the `vercel` plugin.

--- a/plugins/vercel/commands/integration.md
+++ b/plugins/vercel/commands/integration.md
@@ -1,0 +1,8 @@
+---
+name: integration
+description: Discover, install, and configure Vercel Marketplace integrations
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+Invoke the `integration` skill from the `vercel` plugin.

--- a/plugins/vercel/commands/logs.md
+++ b/plugins/vercel/commands/logs.md
@@ -1,0 +1,10 @@
+---
+name: logs
+description: View Vercel deployment logs
+allowed-tools: [Bash, Read]
+user_invocable: true
+---
+
+Invoke the `vercel` skill from the `vercel` plugin and load
+`references/monitoring-and-debugging.md` for the log/debug workflow
+(`vercel logs`, `vercel inspect`, runtime vs build logs).

--- a/plugins/vercel/commands/setup.md
+++ b/plugins/vercel/commands/setup.md
@@ -1,0 +1,8 @@
+---
+name: setup
+description: Set up Vercel CLI and configure project linking
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+Invoke the `setup` skill from the `vercel` plugin.

--- a/plugins/vercel/commands/v0.md
+++ b/plugins/vercel/commands/v0.md
@@ -1,0 +1,8 @@
+---
+name: v0
+description: Generate or iterate on a UI/app with Vercel v0
+allowed-tools: [Bash, Read, Write, Edit]
+user_invocable: true
+---
+
+Invoke the `v0` skill from the `vercel` plugin.

--- a/plugins/vercel/skills/deploy/SKILL.md
+++ b/plugins/vercel/skills/deploy/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: deploy
+description: Deploy applications to Vercel. Use when deploying to preview or production.
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+# Vercel Deploy
+
+Deploy the current project to Vercel (preview or production).
+
+## Prerequisites
+
+1. **Check Vercel CLI is installed**:
+   ```bash
+   vercel --version
+   ```
+   If missing: `npm i -g vercel`
+
+2. **Check project is linked**:
+   ```bash
+   ls .vercel/project.json 2>/dev/null || ls .vercel/repo.json 2>/dev/null || echo "NOT LINKED"
+   ```
+   If not linked, run the setup skill first.
+
+3. **Check correct team**:
+   ```bash
+   vercel whoami
+   ```
+
+## Deploy
+
+### Preview deployment (default)
+```bash
+vercel deploy
+```
+
+### Production deployment
+
+Production deploys overwrite what users see — confirm with the user before
+running. In a monorepo, `cd` into the specific project directory first so the
+right project is targeted.
+
+```bash
+vercel --prod                 # single-project repo
+# OR
+cd apps/web && vercel --prod  # monorepo: deploy one project
+```
+
+### Deploy with prebuilt output
+If `vercel build` was run first:
+```bash
+vercel deploy --prebuilt
+```
+
+### Deploy with environment overrides
+```bash
+vercel deploy --env KEY=value
+```
+
+## Post-Deploy
+
+1. **Display the deployment URL** from the command output.
+2. If errors occur, suggest checking logs with `/vercel:logs`.
+3. For domain configuration, load `references/domains-and-dns.md`.
+
+## Anti-Patterns
+
+- Never use `vercel deploy` after `vercel build` without `--prebuilt` — the build output is ignored.
+- Never hardcode tokens in flags — use `VERCEL_TOKEN` env var.
+- Never use `--yes` to skip Vercel confirmation prompts — let them run.
+
+For full deployment reference, see `references/deployment.md`.

--- a/plugins/vercel/skills/integration/SKILL.md
+++ b/plugins/vercel/skills/integration/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: integration
+description: Discover, install, and configure Vercel Marketplace integrations (databases, auth, logging, etc.). Use when adding third-party services to a Vercel project.
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+# Vercel Integrations
+
+Discover, install, and get setup guides for Vercel Marketplace integrations. Integrations provision third-party services (databases, auth, logging, etc.) and automatically inject environment variables into your project.
+
+## Prerequisites
+
+1. **Check Vercel CLI is installed** (needs latest for integration commands):
+   ```bash
+   vercel --version
+   ```
+   If missing or outdated: `pnpm i -g vercel@latest`
+
+2. **Check project is linked**:
+   ```bash
+   ls .vercel/project.json 2>/dev/null || ls .vercel/repo.json 2>/dev/null || echo "NOT LINKED"
+   ```
+   If not linked, run the setup skill first.
+
+3. **Check correct team**:
+   ```bash
+   vercel whoami
+   ```
+
+## Discover Available Integrations
+
+```bash
+vercel integration discover --format=json
+```
+
+Use `--format=json` for agent-parseable output. Categories include: AI, Analytics, Authentication, CMS, Databases, Logging, Monitoring, Storage, and more.
+
+## Install an Integration
+
+```bash
+# Basic install — provisions resource and injects env vars
+vercel integration add <slug> --format=json
+
+# Specific product (multi-product integrations like Upstash)
+vercel integration add <slug>/<product> --format=json
+
+# With metadata (e.g., region selection)
+vercel integration add <slug> -m primaryRegion=iad1 --format=json
+
+# Custom resource name
+vercel integration add <slug> --name my-db --format=json
+
+# Specific environment(s)
+vercel integration add <slug> -e production -e preview --format=json
+
+# Specific billing plan
+vercel integration add <slug> --plan <plan-id> --format=json
+```
+
+**Browser fallback:** The CLI may open a browser for first-time terms acceptance. It polls and resumes automatically — do not kill the process. Inform the user if this happens.
+
+## Get Setup Guide
+
+```bash
+# General setup guide (returns agent-friendly markdown)
+vercel integration guide <slug>
+
+# Framework-specific guide
+vercel integration guide <slug> --framework nextjs
+```
+
+The guide contains code snippets and configuration steps. Use this after installing to configure the project.
+
+## List Installed Resources
+
+```bash
+vercel integration list --format=json                     # current project
+vercel integration list --all --format=json               # all team resources
+vercel integration list -i <slug> --format=json           # filter by integration
+```
+
+## Workflow: Add and Configure an Integration
+
+1. **Discover** what's available:
+   ```bash
+   vercel integration discover --format=json
+   ```
+
+2. **Install** the integration:
+   ```bash
+   vercel integration add <slug> --format=json
+   ```
+
+3. **Get the setup guide**:
+   ```bash
+   vercel integration guide <slug>
+   ```
+
+4. **Verify env vars were injected**:
+   ```bash
+   vercel env pull
+   cat .env.local | head -20
+   ```
+
+5. **Follow the guide** to wire up the SDK/client in the project code.
+
+## Common Integrations
+
+| Slug | Service | Use Case |
+|------|---------|----------|
+| `neon` | Neon Postgres | Serverless PostgreSQL |
+| `upstash/upstash-redis` | Upstash Redis | Serverless Redis/KV |
+| `upstash/upstash-qstash` | Upstash QStash | Message queue |
+| `supabase` | Supabase | Postgres + Auth + Storage |
+| `clerk` | Clerk | Authentication |
+| `sentry` | Sentry | Error monitoring |
+| `axiom` | Axiom | Logging/observability |
+
+When unsure about available integrations, always run `vercel integration discover` first.
+
+## Disconnect and Remove
+
+```bash
+# Disconnect resource from project (keeps resource alive)
+vercel ir disconnect <resource> --yes
+
+# Delete resource permanently (must disconnect first, or use --disconnect-all)
+vercel ir remove <resource> --disconnect-all --yes
+
+# Uninstall integration entirely (all resources must be deleted first)
+vercel integration remove <slug> --yes
+```
+
+**Destructive commands require `--yes` when using `--format=json`.**
+
+## Anti-Patterns
+
+- **Manually setting env vars for Marketplace services** — use `vercel integration add` instead; it handles provisioning and env var injection.
+- **Killing the CLI during browser-based terms acceptance** — it polls and resumes automatically.
+- **Forgetting `--format=json` in automation** — without it, commands expect interactive TTY input.
+- **Not specifying `/<product>` for multi-product integrations** — errors in non-TTY mode.
+
+For the complete integration reference, see `references/integrations.md`.

--- a/plugins/vercel/skills/setup/SKILL.md
+++ b/plugins/vercel/skills/setup/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: setup
+description: Set up Vercel CLI and configure project linking. Use when first connecting a project to Vercel.
+allowed-tools: [Bash]
+user_invocable: true
+---
+
+# Vercel Setup
+
+First-time setup: install CLI, authenticate, link project, pull environment variables.
+
+## Steps
+
+### 1. Install Vercel CLI
+```bash
+vercel --version 2>/dev/null || npm i -g vercel
+```
+
+### 2. Authenticate
+```bash
+vercel login
+```
+Follow the browser prompt to complete authentication.
+
+### 3. Link project
+
+**Single project (most cases)**:
+```bash
+vercel link
+```
+
+**Monorepo with multiple Vercel projects**:
+```bash
+vercel link --repo
+```
+
+Monorepo decision: if the repo has multiple apps each deployed separately (e.g., `apps/web`, `apps/api`), use `--repo`. Otherwise, `vercel link` is fine.
+
+### 4. Verify linking
+```bash
+cat .vercel/project.json 2>/dev/null || cat .vercel/repo.json 2>/dev/null
+```
+
+### 5. Pull environment variables
+```bash
+vercel pull
+```
+This creates `.vercel/.env.development.local` with your project's env vars.
+
+### 6. Verify setup
+```bash
+vercel whoami && vercel project ls
+```
+
+## Post-Setup
+
+- Run `vercel dev` to start local development with Vercel's serverless functions.
+- Run `vercel deploy` for a preview deployment.
+- See `references/getting-started.md` and `references/environment-variables.md` for details.
+
+## Anti-Patterns
+
+- Don't let commands auto-link in monorepos — always run `vercel link` (or `--repo`) explicitly first.
+- Don't link while on the wrong team — check with `vercel whoami`, switch with `vercel teams switch`.

--- a/plugins/vercel/skills/v0/SKILL.md
+++ b/plugins/vercel/skills/v0/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: v0
+description: Generate and iterate on UIs/apps with Vercel v0 via the v0 Platform API. Use when building a frontend with v0, calling the v0 API/SDK, or spending v0 credits.
+allowed-tools: [Bash, Read, Write, Edit]
+user_invocable: true
+---
+
+# Vercel v0
+
+[v0](https://v0.app) is Vercel's AI app builder. Beyond the web UI at
+`v0.app`, it exposes a **Platform API** (and an OpenAI-compatible model API) so
+you can generate UIs, components, and full apps from code.
+
+> **Hackathon note:** participants receive **v0 credits**. The API bills
+> against those credits, so you can drive v0 from the CLI without a paid
+> upgrade as long as credits remain. Check usage at
+> [v0.app/chat/settings/billing](https://v0.app/chat/settings/billing).
+
+There are two distinct surfaces — pick the right one:
+
+| Surface | Package / endpoint | Use it for |
+|---------|--------------------|------------|
+| **Platform API** | `v0-sdk` (npm), `https://api.v0.dev/v1` | Create/iterate **chats** that return generated files, demos, and deployable projects. This is the real "v0 builds my app" surface. |
+| **Model API** | AI SDK `@ai-sdk/vercel`, `https://api.v0.dev/v1` (OpenAI-compatible) | Use v0's models (`v0-1.5-md`, etc.) as a chat/completions model inside your own app. |
+
+## Setup (do this first)
+
+1. **Get an API key** — [v0.app/chat/settings/keys](https://v0.app/chat/settings/keys).
+   The key grants full access to the v0 account — treat it as a secret.
+2. **Store it as an env var**, never in code or flags. Add to `.env` (gitignored):
+   ```bash
+   echo 'V0_API_KEY=your-v0-api-key' >> .env
+   ```
+   The SDK and CLI read `V0_API_KEY` automatically.
+3. **Verify access:**
+   ```bash
+   curl -s https://api.v0.dev/v1/user \
+     -H "Authorization: Bearer $V0_API_KEY" | head
+   ```
+   A JSON user object means the key works. `401` means the key is wrong or
+   credits/billing aren't enabled on the account.
+
+## Fastest path: scaffold a v0-powered app
+
+```bash
+# Spins up a Next.js app pre-wired to the v0 Platform API
+pnpm create v0-sdk-app@latest my-v0-app
+# or: npx create-v0-sdk-app@latest my-v0-app
+```
+
+## Platform API via the SDK (generate UI from a prompt)
+
+```bash
+pnpm add v0-sdk        # or: npm install v0-sdk
+```
+
+```ts
+import { v0 } from 'v0-sdk' // reads V0_API_KEY from the environment
+
+// Create a chat — v0 generates the app and returns a live demo + files
+const chat = await v0.chats.create({
+  message: 'Build a landing page for a biotech hackathon with a hero and signup form',
+})
+
+console.log('Preview:', chat.demo)        // hosted preview URL
+console.log('Chat:', chat.url)            // open/iterate in the v0 web UI
+// chat.files[] holds the generated source files
+
+// Iterate on the same chat
+const next = await v0.chats.sendMessage({
+  chatId: chat.id,
+  message: 'Make the hero dark mode and add a pricing section',
+})
+```
+
+## Model API (use v0 as a model in your own app)
+
+```bash
+pnpm add ai @ai-sdk/vercel
+```
+
+```ts
+import { generateText } from 'ai'
+import { vercel } from '@ai-sdk/vercel' // reads V0_API_KEY
+
+const { text } = await generateText({
+  model: vercel('v0-1.5-md'),
+  prompt: 'Generate a React component for a file-upload dropzone with Tailwind',
+})
+```
+
+Or hit it directly — it's OpenAI-compatible:
+
+```bash
+curl https://api.v0.dev/v1/chat/completions \
+  -H "Authorization: Bearer $V0_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"v0-1.5-md","messages":[{"role":"user","content":"a pricing table component"}]}'
+```
+
+## Ship what v0 builds
+
+v0 projects deploy to Vercel. After pulling the generated files into a repo,
+use the `deploy` skill (`/vercel:deploy`) or link the v0 project to Vercel from
+the v0 UI. Production deploys overwrite live URLs — confirm with the user first.
+
+## Anti-Patterns
+
+- Never put `V0_API_KEY` in code, flags, or commits — env var only.
+- Don't confuse the two surfaces: `v0-sdk` (build apps) vs `@ai-sdk/vercel`
+  (use v0 as a model). They share the key and base URL but solve different jobs.
+- The API spends credits/usage on every call — don't loop generations blindly;
+  check remaining credits if calls start failing.
+
+## Reference
+
+- Platform API overview: <https://v0.app/docs/api/platform/overview>
+- `v0-sdk` package docs: <https://v0.app/docs/api/platform/packages/v0-sdk>
+- Quickstart: <https://v0.app/docs/api/platform/quickstart>

--- a/plugins/vercel/skills/vercel/SKILL.md
+++ b/plugins/vercel/skills/vercel/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: vercel
+description: Deploy, manage, and develop projects on Vercel from the command line
+user_invocable: true
+---
+
+# Vercel CLI Skill
+
+The Vercel CLI (`vercel` or `vc`) deploys, manages, and develops projects on the Vercel platform from the command line. Use `vercel <command> -h` for full flag details on any command.
+
+## Critical: Project Linking
+
+Commands must be run from the directory containing the `.vercel` folder (or a subdirectory of it). How `.vercel` gets set up depends on your project structure:
+
+- **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
+- **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
+
+Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt since it's unambiguous.
+
+**When something goes wrong, check how things are linked first** — look at what's in `.vercel/` and whether it's `project.json` or `repo.json`. Also verify you're on the right team with `vercel whoami` — linking while on the wrong team is a common mistake.
+
+## Quick Start
+
+```bash
+npm i -g vercel
+vercel login
+vercel link              # single project
+# OR
+vercel link --repo       # monorepo
+vercel pull
+vercel dev        # local development
+vercel deploy     # preview deployment
+vercel --prod     # production deployment
+```
+
+## Decision Tree
+
+Use this to route to the correct reference file:
+
+- **Deploy** → `references/deployment.md`
+- **Local development** → `references/local-development.md`
+- **Environment variables** → `references/environment-variables.md`
+- **CI/CD automation** → `references/ci-automation.md`
+- **Domains or DNS** → `references/domains-and-dns.md`
+- **Projects or teams** → `references/projects-and-teams.md`
+- **Logs, debugging, or accessing preview deploys** → `references/monitoring-and-debugging.md`
+- **Blob storage** → `references/storage.md`
+- **Integrations (databases, storage, etc.)** → use the `integration` skill, or `references/integrations.md` for deep reference
+- **Access a preview deployment** → use `vercel curl` (see `references/monitoring-and-debugging.md`)
+- **CLI doesn't have a command for it** → use `vercel api` as a fallback (see `references/advanced.md`)
+- **Node.js backends (Express, Hono, etc.)** → `references/node-backends.md`
+- **Monorepos (Turborepo, Nx, workspaces)** → `references/monorepos.md`
+- **Bun runtime** → `references/bun.md`
+- **Advanced (API, webhooks)** → `references/advanced.md`
+- **Global flags** → `references/global-options.md`
+- **First-time setup** → `references/getting-started.md`
+- **REST API endpoints** → `references/rest-api-reference.md`
+- **Complete CLI command/flag reference** → `references/cli-complete-reference.md`
+
+## Comprehensive API & CLI Reference (Vault)
+
+For the full authoritative reference (49 CLI commands, 250+ REST API endpoints, TypeScript SDK, Terraform provider, `vercel.json` config, platform limits), load the vault doc:
+
+**Path**: `09-engineering/integrations/vercel-cli-and-rest-api-reference.md`
+
+Use the knowledge-base plugin to read this when you need to:
+- Make direct REST API calls (`vercel api` or `curl`)
+- Use the `@vercel/sdk` TypeScript SDK
+- Look up exact endpoint paths, methods, and parameters
+- Check platform limits or `vercel.json` configuration options
+- Build new automation that needs specific API endpoints
+
+The reference files in this plugin cover common workflows. The vault doc is the complete source for everything Vercel exposes.
+
+## Anti-Patterns
+
+- **Wrong link type in monorepos with multiple projects**: `vercel link` creates `project.json`, which only tracks one project. Use `vercel link --repo` instead. When things break, check `.vercel/` first.
+- **Letting commands auto-link in monorepos**: Many commands implicitly run `vercel link` if `.vercel/` doesn't exist. This creates `project.json`, which may be wrong. Run `vercel link` (or `--repo`) explicitly first.
+- **Linking while on the wrong team**: Use `vercel whoami` to check, `vercel teams switch` to change.
+- **Forgetting `--yes` in CI**: Required to skip interactive prompts.
+- **Using `vercel deploy` after `vercel build` without `--prebuilt`**: The build output is ignored.
+- **Hardcoding tokens in flags**: Use `VERCEL_TOKEN` env var instead of `--token`.
+- **Disabling deployment protection**: Use `vercel curl` instead to access preview deploys.

--- a/plugins/vercel/skills/vercel/references/advanced.md
+++ b/plugins/vercel/skills/vercel/references/advanced.md
@@ -1,0 +1,22 @@
+# Advanced Commands
+
+## `vercel api` — Fallback for Missing CLI Commands
+
+**Use `vercel api` when a CLI command doesn't exist for what you need.** Full access to the Vercel REST API with automatic authentication.
+
+```bash
+vercel api /v2/user                                    # GET current user
+vercel api /v9/projects --scope my-team                # list projects
+vercel api /v10/projects -X POST -F name=my-project    # create project
+vercel api /v6/deployments --paginate                  # paginate all results
+vercel api ls                                          # list available endpoints
+```
+
+Use `vercel api ls` to discover available endpoints.
+
+## Other Commands
+
+- `vercel webhooks` — manage webhooks (create, ls, rm)
+- `vercel mcp` — set up MCP integration for AI agents
+- `vercel telemetry` — manage telemetry settings
+- `vercel upgrade` — upgrade the CLI

--- a/plugins/vercel/skills/vercel/references/bun.md
+++ b/plugins/vercel/skills/vercel/references/bun.md
@@ -1,0 +1,71 @@
+# Bun on Vercel
+
+Vercel supports Bun as a runtime. To enable it, add `"bunVersion": "1.x"` to your `vercel.json`:
+
+```json
+{
+  "bunVersion": "1.x"
+}
+```
+
+That's it. Vercel will use Bun instead of Node.js to run your project.
+
+This works with any framework — backend apps (Express, Hono, Elysia), frontend frameworks, or anything else. Bun is used as the runtime, so Bun-specific APIs and features are available.
+
+## Example: Elysia with Bun
+
+Elysia is a Bun-native framework. To use it on Vercel:
+
+**vercel.json:**
+
+```json
+{
+  "bunVersion": "1.x"
+}
+```
+
+**package.json:**
+
+```json
+{
+  "type": "module",
+  "dependencies": {
+    "elysia": "^1.0.0"
+  }
+}
+```
+
+**server.ts:**
+
+```typescript
+import { Elysia } from 'elysia';
+
+const app = new Elysia().get('/', () => 'Hello Elysia!');
+
+export default app;
+```
+
+## Example: Next.js with Bun
+
+**vercel.json:**
+
+```json
+{
+  "bunVersion": "1.x"
+}
+```
+
+**package.json:**
+
+```json
+{
+  "scripts": {
+    "dev": "bun run --bun next dev",
+    "build": "bun run --bun next build"
+  }
+}
+```
+
+## Anti-Patterns
+
+- **Forgetting `bunVersion` in `vercel.json`**: Without it, your project runs on Node.js. Bun-specific APIs (like `Bun.file()`) will fail at runtime.

--- a/plugins/vercel/skills/vercel/references/ci-automation.md
+++ b/plugins/vercel/skills/vercel/references/ci-automation.md
@@ -1,0 +1,56 @@
+# CI/CD Automation
+
+## Authentication
+
+Use `VERCEL_TOKEN` env var (not `--token` — it leaks in process listings). Use `--scope` if the token has access to multiple teams.
+
+## The Standard CI Deploy Pattern
+
+```bash
+vercel pull --yes --environment=production
+vercel build --prod
+vercel deploy --prebuilt --prod
+```
+
+For multi-project monorepos, ensure `vercel link --repo --yes` has been run first.
+
+## Separate Build and Deploy Jobs
+
+Use `--standalone` so build artifacts are self-contained and can be passed between jobs:
+
+```yaml
+jobs:
+  build:
+    steps:
+      - run: vercel pull --yes --environment=production
+      - run: vercel build --prod --standalone
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vercel-build
+          path: .vercel/output
+
+  deploy:
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vercel-build
+          path: .vercel/output
+      - run: vercel deploy --prebuilt --prod
+```
+
+Without `--standalone`, the deploy job will fail because artifacts reference files outside `.vercel/output/`.
+
+## Capturing the Deploy URL
+
+```bash
+URL=$(vercel deploy --prod)   # stdout = URL, stderr = progress
+```
+
+## Key Rules
+
+1. Always use `--yes` to skip prompts
+2. Always use `VERCEL_TOKEN` env var for auth
+3. Use `--scope` if the token has access to multiple teams
+4. Use `vercel build` + `vercel deploy --prebuilt` for deterministic builds
+5. If something goes wrong, check `.vercel/` — `project.json` vs `repo.json` is the most common issue

--- a/plugins/vercel/skills/vercel/references/cli-complete-reference.md
+++ b/plugins/vercel/skills/vercel/references/cli-complete-reference.md
@@ -1,0 +1,664 @@
+# Vercel CLI Complete Command Reference
+
+Install: `npm i -g vercel`
+
+## Global Options (apply to all commands)
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--cwd <path>` | | Working directory |
+| `--debug` | `-d` | Verbose output |
+| `--global-config <dir>` | `-Q` | Path to global `.vercel` directory |
+| `--help` | `-h` | Show help |
+| `--local-config <file>` | `-A` | Path to local `vercel.json` |
+| `--no-color` | | Disable colored output (respects `NO_COLOR`) |
+| `--scope <team>` | `-S` | Execute as different scope |
+| `--team <slug|id>` | `-T` | Specify team |
+| `--token <token>` | `-t` | Auth token (for CI/CD) |
+| `--project <name|id>` | | Specify project |
+| `--version` | `-v` | Show CLI version |
+
+Environment variables for CI/CD:
+- `VERCEL_TOKEN` — auth token
+- `VERCEL_ORG_ID` — team/org ID
+- `VERCEL_PROJECT_ID` — project ID
+- `VERCEL_AUTOMATION_BYPASS_SECRET` — deployment protection bypass
+
+---
+
+## deploy (default command)
+
+Deploy projects. Can be invoked as just `vercel` without subcommand.
+
+```bash
+vercel [path]
+vercel deploy [path]
+vercel --prod
+vercel deploy --prebuilt
+vercel deploy --prebuilt --archive=tgz
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--prod` | | Production deployment |
+| `--prebuilt` | | Deploy pre-built output from `vercel build` |
+| `--archive <tgz>` | | Compress prebuilt output for upload |
+| `--env KEY=val` | `-e` | Runtime env var (repeatable) |
+| `--build-env KEY=val` | `-b` | Build-time env var (repeatable) |
+| `--meta KEY=val` | `-m` | Deployment metadata (repeatable) |
+| `--regions <list>` | | Serverless function regions (e.g., `sfo1,iad1`) |
+| `--target <env>` | | Custom deployment environment |
+| `--force` | `-f` | Force fresh build (bypass cache) |
+| `--with-cache` | | Retain build cache when using `--force` |
+| `--no-wait` | | Return immediately without waiting |
+| `--skip-domain` | | Skip auto-assigning production domains (use with `--prod`) |
+| `--name <name>` | `-n` | Project name (deprecated, use `vercel link`) |
+| `--public` | `-p` | Make `/_src` publicly accessible |
+| `--no-clipboard` | `-C` | Don't copy URL to clipboard |
+| `--yes` | `-y` | Skip confirmation prompts |
+| `--guidance` | | Show suggested next steps |
+
+## dev
+
+Local development server replicating Vercel environment.
+
+```bash
+vercel dev
+vercel dev --listen 5005
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--listen <port>` | `-l` | Port to listen on |
+| `--yes` | `-y` | Skip setup questions |
+
+## build
+
+Build project locally for later deployment with `--prebuilt`.
+
+```bash
+vercel build
+vercel build --prod
+```
+
+| Flag | Description |
+|------|-------------|
+| `--prod` | Use production env vars |
+| `--yes` | Auto-pull env vars if missing |
+| `--target <env>` | Build against specific environment |
+| `--output <dir>` | Custom output directory (default: `.vercel/output`) |
+
+## env
+
+Manage environment variables.
+
+```bash
+vercel env ls
+vercel env add <name> [environment] [gitbranch]
+vercel env add <name> <environment> < file.txt
+vercel env update <name> [environment]
+vercel env rm <name> [environment]
+vercel env pull [file]
+vercel env run -- <command>
+vercel env run -e production -- npm test
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--environment <env>` | `-e` | Target environment |
+| `--git-branch <branch>` | | Branch-specific variable |
+
+## pull
+
+Download env vars and project settings to local cache.
+
+```bash
+vercel pull
+vercel pull --environment=production
+vercel pull --git-branch=feature-x
+```
+
+| Flag | Description |
+|------|-------------|
+| `--environment <env>` | Which environment to pull |
+| `--git-branch <branch>` | Pull branch-specific vars |
+| `--yes` | Skip questions |
+
+## link
+
+Associate local directory with Vercel project.
+
+```bash
+vercel link
+vercel link [path]
+vercel link --repo
+```
+
+| Flag | Description |
+|------|-------------|
+| `--repo` | Link entire repository (for monorepos, alpha) |
+| `--yes` | Skip questions |
+| `--project <name|id>` | Non-interactive project selection |
+
+## login / logout / whoami
+
+```bash
+vercel login [email]
+vercel logout
+vercel whoami
+```
+
+## teams
+
+```bash
+vercel teams list
+vercel teams add
+vercel teams invite <email>
+```
+
+Alias: `vercel switch [team-name]` to change active scope.
+
+## project
+
+```bash
+vercel project ls [--json] [--update-required]
+vercel project add <name>
+vercel project rm <name>
+vercel project inspect [name]
+```
+
+## list (ls)
+
+List recent deployments.
+
+```bash
+vercel list [project-name]
+vercel ls
+```
+
+## inspect
+
+Get deployment details.
+
+```bash
+vercel inspect <deployment-url|id>
+vercel inspect <url> --logs
+vercel inspect <url> --wait --timeout 5m
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--logs` | `-l` | Print build logs |
+| `--wait` | | Wait for deployment to finish |
+| `--timeout <duration>` | | Max wait time |
+
+## logs
+
+View request and runtime logs.
+
+```bash
+vercel logs
+vercel logs --follow
+vercel logs --environment production --status-code 5xx --since 30m
+```
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--follow` | `-f` | Stream live logs |
+| `--project <id|name>` | | Filter by project |
+| `--deployment <id|url>` | | Filter by deployment |
+| `--environment <env>` | | Filter: `production` or `preview` |
+| `--level <level>` | | `error`, `warning`, `info`, `fatal` (repeatable) |
+| `--status-code <code>` | | HTTP status, supports `4xx`, `5xx` wildcards |
+| `--source <src>` | | `serverless`, `edge-function`, `edge-middleware`, `static` |
+| `--branch <branch>` | | Filter by git branch |
+| `--json` | | JSON Lines output (pipe to `jq`) |
+| `--expand` | | Full message details |
+| `--query <text>` | | Search logs for text |
+| `--since <duration>` | | Time filter: `1h`, `30m`, `5d` |
+
+## domains
+
+```bash
+vercel domains ls [--limit N] [--next <timestamp>]
+vercel domains inspect <domain>
+vercel domains add <domain> [project]
+vercel domains rm <domain> [--yes]
+vercel domains buy <domain>
+vercel domains move <domain> <scope>
+vercel domains transfer-in <domain>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Force domain onto project (removes from existing) |
+| `--limit <N>` | Max results (default 20, max 100) |
+| `--next <ts>` | Pagination cursor |
+| `--yes` | Skip confirmation |
+
+## dns
+
+```bash
+vercel dns ls [domain] [--limit N]
+vercel dns add <domain> <name> <type> <value> [mxPriority|srvData]
+vercel dns rm <record-id>
+vercel dns import <domain> <zonefile>
+```
+
+Supported record types: `A`, `AAAA`, `ALIAS`, `CNAME`, `TXT`, `MX`, `SRV`, `CAA`.
+
+## certs
+
+```bash
+vercel certs ls [--limit N]
+vercel certs issue <domain> [domain2...]
+vercel certs rm <certificate-id>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--challenge-only` | Show challenges without completing |
+| `--limit <N>` | Max results |
+
+## alias
+
+```bash
+vercel alias set <deployment-url> <custom-domain>
+vercel alias rm <custom-domain>
+vercel alias ls
+```
+
+## remove (rm)
+
+```bash
+vercel remove <deployment-url>
+vercel remove <project-name>
+```
+
+## redeploy
+
+```bash
+vercel redeploy [deployment-id-or-url]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--no-wait` | Return immediately |
+| `--target <env>` | Target environment |
+
+## rollback
+
+```bash
+vercel rollback [deployment-url-or-id]
+vercel rollback status
+```
+
+| Flag | Description |
+|------|-------------|
+| `--timeout <duration>` | Max wait time |
+
+Hobby: only previous deployment. Pro/Enterprise: any previous deployment.
+
+## promote
+
+```bash
+vercel promote <deployment-url-or-id>
+vercel promote status
+```
+
+| Flag | Description |
+|------|-------------|
+| `--yes` | Skip confirmation (preview to prod) |
+| `--timeout <duration>` | Max wait time |
+
+## bisect
+
+Binary search across deployments to find when bugs were introduced.
+
+```bash
+vercel bisect
+vercel bisect --good <url> --bad <url>
+vercel bisect --good <url> --bad <url> --run ./test.sh
+```
+
+| Flag | Description |
+|------|-------------|
+| `--good <url>` | Known good deployment |
+| `--bad <url>` | Known bad deployment |
+| `--path <subpath>` | Subpath where issue occurs |
+| `--open` | Auto-open URLs in browser |
+| `--run <script>` | Automated test (exit 0=good, non-zero=bad, 125=skip) |
+
+## cache
+
+```bash
+vercel cache purge [--type cdn|data]
+vercel cache invalidate --tag <tags>
+vercel cache invalidate --srcimg <path>
+vercel cache dangerously-delete --tag <tags>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--tag <tags>` | Cache tags (comma-separated) |
+| `--srcimg <path>` | Source image path (image optimization) |
+| `--revalidation-deadline-seconds <N>` | Time window for deletion |
+| `--yes` | Skip confirmation |
+
+## flags
+
+Feature flag management.
+
+```bash
+vercel flags list [--state active|archived]
+vercel flags add <name> [--kind boolean|string|number] [-d "desc"] [-e production]
+vercel flags inspect <name>
+vercel flags enable <name> -e <environment>
+vercel flags disable <name> [-e <env>] [--variant <v>]
+vercel flags archive <name>
+vercel flags rm <name> [--yes]
+```
+
+SDK keys:
+```bash
+vercel flags sdk-keys ls
+vercel flags sdk-keys add --type server|client --environment <env> [--label "desc"]
+vercel flags sdk-keys rm <key-id>
+```
+
+## redirects
+
+Manage project-level redirects at scale (no redeployment needed).
+
+```bash
+vercel redirects list [--page N] [--per-page N] [--search <text>] [--staged] [--version <id>]
+vercel redirects add /old /new --status 301 [--case-sensitive] [--preserve-query-params] [--name <version-name>]
+vercel redirects upload <file.csv|file.json> [--overwrite] [--name <version-name>]
+vercel redirects list-versions
+vercel redirects promote <version-id>
+vercel redirects restore <version-id>
+vercel redirects remove <redirect-id> [--yes]
+```
+
+## rolling-release
+
+Gradual production rollout.
+
+```bash
+vercel rolling-release configure --cfg '<json>'
+vercel rolling-release start --dpl <deployment-url>
+vercel rolling-release approve --dpl <url> --currentStageIndex <N>
+vercel rolling-release complete --dpl <url>
+vercel rolling-release abort --dpl <url>
+```
+
+## git
+
+```bash
+vercel git ls
+vercel git connect [--yes]
+vercel git disconnect [--yes]
+```
+
+## blob
+
+Vercel Blob storage.
+
+```bash
+vercel blob list
+vercel blob put <path-to-file>
+vercel blob get <url-or-pathname>
+vercel blob del <url-or-pathname>
+vercel blob copy <source> <destination>
+```
+
+## integration
+
+```bash
+vercel integration add <name>
+vercel integration list [project]
+vercel integration discover
+vercel integration guide <name>
+vercel integration balance <name>
+vercel integration open <name>
+vercel integration remove <name>
+```
+
+## integration-resource
+
+```bash
+vercel integration-resource remove <resource-name>
+vercel integration-resource disconnect <resource-name> [project-name]
+vercel integration-resource create-threshold <resource-name> <minimum> <spend> <limit>
+```
+
+## target
+
+Custom environment management.
+
+```bash
+vercel target list
+vercel target ls
+```
+
+## microfrontends (mf)
+
+```bash
+vercel microfrontends pull [--dpl <deployment-id-or-url>]
+vercel mf pull
+```
+
+## curl / httpstat
+
+Access deployments with automatic protection bypass.
+
+```bash
+vercel curl [path]
+vercel curl /api/hello --deployment <url>
+vercel httpstat [path]
+vercel httpstat /api/data --deployment <url>
+```
+
+| Flag | Description |
+|------|-------------|
+| `--deployment <url>` | Target deployment URL |
+| `--protection-bypass <secret>` | Custom bypass secret |
+
+## telemetry
+
+```bash
+vercel telemetry status
+vercel telemetry enable
+vercel telemetry disable
+```
+
+## open
+
+```bash
+vercel open
+```
+
+Opens current project in Vercel Dashboard.
+
+## init
+
+```bash
+vercel init [example-name]
+```
+
+Initialize from example repository.
+
+## help
+
+```bash
+vercel help
+vercel help <command>
+```
+
+---
+
+## vercel.json Configuration Reference
+
+Place in project root. Schema: `https://openapi.vercel.sh/vercel.json`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `buildCommand` | `string \| null` | Override build command |
+| `cleanUrls` | `boolean` | Remove extensions from URLs (default: false) |
+| `crons` | `array` | Cron job definitions (`path` + `schedule`) |
+| `devCommand` | `string \| null` | Override dev command |
+| `framework` | `string \| null` | Framework preset (`nextjs`, `vite`, etc.; `null` for "Other") |
+| `functions` | `object` | Serverless function config by glob pattern |
+| `headers` | `array` | Custom response headers |
+| `ignoreCommand` | `string` | Command to decide if build should be skipped |
+| `images` | `object` | Image optimization config |
+| `installCommand` | `string \| null` | Override install command |
+| `outputDirectory` | `string` | Build output directory |
+| `public` | `boolean` | Expose source view and logs |
+| `redirects` | `array` | Redirect rules |
+| `regions` | `array` | Serverless function regions |
+| `functionFailoverRegion` | `string` | Failover region |
+| `rewrites` | `array` | Rewrite rules |
+| `trailingSlash` | `boolean` | Redirect to trailing-slash or non-trailing-slash |
+| `git.deploymentEnabled` | `boolean` | Enable/disable auto-deploy on push |
+
+### functions
+
+```json
+{
+  "functions": {
+    "api/heavy.js": { "memory": 3009, "maxDuration": 30 },
+    "api/*.js": { "memory": 1024, "maxDuration": 10 }
+  }
+}
+```
+
+Properties: `memory` (128-3009 MB), `maxDuration` (seconds), `runtime` (npm package).
+
+### crons
+
+```json
+{
+  "crons": [
+    { "path": "/api/cron/daily", "schedule": "0 8 * * *" }
+  ]
+}
+```
+
+Max path: 512 chars. Max schedule: 256 chars. Max per project: 100 (Hobby/Pro).
+
+### redirects
+
+```json
+{
+  "redirects": [
+    { "source": "/old", "destination": "/new", "permanent": true },
+    { "source": "/temp", "destination": "/new", "statusCode": 307 }
+  ]
+}
+```
+
+Properties: `source`, `destination`, `permanent` (308/307), `statusCode` (301/302/307/308), `has` (conditional), `missing`.
+
+### rewrites
+
+```json
+{
+  "rewrites": [
+    { "source": "/api/:path*", "destination": "https://backend.example.com/:path*" }
+  ]
+}
+```
+
+### headers
+
+```json
+{
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" }
+      ]
+    }
+  ]
+}
+```
+
+### images
+
+```json
+{
+  "images": {
+    "sizes": [640, 750, 828, 1080, 1200],
+    "domains": ["example.com"],
+    "remotePatterns": [{ "protocol": "https", "hostname": "**.example.com" }],
+    "minimumCacheTTL": 60,
+    "formats": ["image/avif", "image/webp"]
+  }
+}
+```
+
+### Conditional matching (has/missing)
+
+Available in redirects, rewrites, and headers:
+
+```json
+{
+  "has": [
+    { "type": "host", "value": "www.example.com" },
+    { "type": "header", "key": "x-custom" },
+    { "type": "query", "key": "page", "value": "(?P<page>.*)" },
+    { "type": "cookie", "key": "session" }
+  ]
+}
+```
+
+Types: `host`, `header`, `query`, `cookie`.
+
+---
+
+## System Environment Variables
+
+Automatically available when enabled in project settings:
+
+| Variable | Available At | Description |
+|----------|-------------|-------------|
+| `VERCEL` | Build + Runtime | Always `1` |
+| `CI` | Build | Always `1` |
+| `VERCEL_ENV` | Build + Runtime | `production`, `preview`, or `development` |
+| `VERCEL_TARGET_ENV` | Build + Runtime | Same as above, or custom env name |
+| `VERCEL_URL` | Build + Runtime | Deployment URL (no `https://`) |
+| `VERCEL_BRANCH_URL` | Build + Runtime | Git branch URL |
+| `VERCEL_PROJECT_PRODUCTION_URL` | Build + Runtime | Shortest production domain |
+| `VERCEL_REGION` | Runtime | Region ID (e.g., `cdg1`) |
+| `VERCEL_DEPLOYMENT_ID` | Build + Runtime | Deployment ID |
+| `VERCEL_GIT_PROVIDER` | Build + Runtime | `github`, `gitlab`, `bitbucket` |
+| `VERCEL_GIT_REPO_SLUG` | Build + Runtime | Repository name |
+| `VERCEL_GIT_REPO_OWNER` | Build + Runtime | Repository owner |
+| `VERCEL_GIT_REPO_ID` | Build + Runtime | Repository ID |
+| `VERCEL_GIT_COMMIT_REF` | Build + Runtime | Git branch |
+| `VERCEL_GIT_COMMIT_SHA` | Build + Runtime | Commit SHA |
+| `VERCEL_GIT_COMMIT_MESSAGE` | Build + Runtime | Commit message |
+| `VERCEL_GIT_COMMIT_AUTHOR_LOGIN` | Build + Runtime | Commit author |
+| `VERCEL_GIT_COMMIT_AUTHOR_NAME` | Build + Runtime | Commit author name |
+| `VERCEL_GIT_PULL_REQUEST_ID` | Build + Runtime | PR number |
+
+---
+
+## Platform Limits (Key Numbers)
+
+| Limit | Hobby | Pro | Enterprise |
+|-------|-------|-----|-----------|
+| Projects | 200 | Unlimited | Unlimited |
+| Deploys/day | 100 | 6,000 | Custom |
+| CLI deploys/week | 2,000 | 2,000 | 2,000 |
+| Build timeout | 45 min | 45 min | 45 min |
+| Static file upload | 100 MB | 1 GB | Custom |
+| Concurrent builds | 1 | 12 | Custom |
+| Disk size | 23 GB | 23-64 GB | Custom |
+| Cron jobs/project | 100 | 100 | 100 |
+| Routes/deployment | 2,048 | 2,048 | 2,048 |
+| Function memory | 128-3,009 MB | 128-3,009 MB | Custom |
+| Proxy request timeout | 120s | 120s | 120s |

--- a/plugins/vercel/skills/vercel/references/deployment.md
+++ b/plugins/vercel/skills/vercel/references/deployment.md
@@ -1,0 +1,72 @@
+# Deployment
+
+Ensure `.vercel/` exists before deploying (via `vercel link` or `vercel link --repo`).
+
+## Basic Usage
+
+```bash
+vercel                    # preview deployment (default)
+vercel --prod             # production deployment
+vercel --target staging   # custom environment
+```
+
+## Prebuilt Deploy
+
+Build locally, deploy the output — avoids remote builds:
+
+```bash
+vercel build --prod
+vercel deploy --prebuilt --prod
+```
+
+If build and deploy run in **separate CI jobs**, use `--standalone` so artifacts are self-contained:
+
+```bash
+vercel build --prod --standalone
+# (upload .vercel/output/ as artifact, then in deploy job:)
+vercel deploy --prebuilt --prod
+```
+
+## Deploy Output
+
+- **stdout**: The deployment URL (pipeable)
+- **stderr**: Progress and errors
+
+```bash
+URL=$(vercel deploy --prod)
+```
+
+## Accessing Preview Deployments
+
+Use `vercel curl` — it handles deployment protection automatically:
+
+```bash
+vercel curl /api/health --deployment $PREVIEW_URL
+```
+
+**Do not disable deployment protection.** Use `vercel curl` instead.
+
+## Other Deploy Commands
+
+- `vercel redeploy <url>` — rebuild an existing deployment
+- `vercel promote <url>` — move a deployment to production without rebuilding
+- `vercel rollback <url>` — revert to a previous deployment
+- `vercel rolling-release` — gradual traffic shifting
+
+## Workflows
+
+### Blue/Green
+
+```bash
+URL=$(vercel --prod --skip-domain)   # deploy without domain assignment
+vercel curl / --deployment $URL      # verify (handles deployment protection)
+vercel promote $URL                  # promote to production
+```
+
+### Rolling Release
+
+```bash
+vercel rr configure --enable --stage=10,5m --stage=50,10m --stage=100,0
+vercel rr start --dpl=<deployment-url>
+vercel rr status
+```

--- a/plugins/vercel/skills/vercel/references/domains-and-dns.md
+++ b/plugins/vercel/skills/vercel/references/domains-and-dns.md
@@ -1,0 +1,29 @@
+# Domains & DNS
+
+## Overview
+
+- `vercel domains` — manage domain ownership and project assignment
+- `vercel dns` — manage DNS records (when using Vercel nameservers)
+- `vercel alias` — map deployment URLs to custom domains
+- `vercel certs` — manage SSL certificates (usually auto-managed)
+
+Most users only need `vercel alias` — domains and DNS are auto-configured when using Vercel nameservers.
+
+## Typical Flow
+
+1. Add domain to project: `vercel domains add example.com my-project`
+2. Configure nameservers at registrar to point to Vercel
+3. Deploy: `vercel --prod` (domain is auto-assigned)
+
+Or manually alias: `vercel alias set <deployment-url> example.com`
+
+## DNS Records
+
+```bash
+vercel dns ls example.com
+vercel dns add example.com @ A 1.2.3.4
+vercel dns add example.com sub CNAME target.example.com
+vercel dns rm rec_abc123
+```
+
+Use `vercel <command> -h` for full flag details.

--- a/plugins/vercel/skills/vercel/references/environment-variables.md
+++ b/plugins/vercel/skills/vercel/references/environment-variables.md
@@ -1,0 +1,39 @@
+# Environment Variables
+
+## Scoping
+
+Env vars are scoped to **environments**: production, preview (can be branch-specific), and development.
+
+Variables can be plain text or sensitive (encrypted, not readable after creation).
+
+## Managing Env Vars
+
+```bash
+vercel env add API_KEY production              # add to production
+vercel env ls                                  # list all
+vercel env update API_KEY production           # update value
+vercel env rm API_KEY preview                  # remove from preview
+echo "secret" | vercel env add TOKEN production  # pipe value from stdin
+```
+
+Note: `environment` is a **positional argument**, not a flag.
+
+## Pulling Locally
+
+```bash
+vercel env pull                   # writes to .env.local
+vercel env pull .env.development  # writes to custom file
+```
+
+`vercel pull` also downloads env vars along with project config.
+
+## Running with Env Vars
+
+Inject env vars into a subprocess without writing to a file:
+
+```bash
+vercel env run -- npm test
+vercel env run -e preview -- next dev
+```
+
+The `--` separator is required before the command.

--- a/plugins/vercel/skills/vercel/references/getting-started.md
+++ b/plugins/vercel/skills/vercel/references/getting-started.md
@@ -1,0 +1,26 @@
+# Getting Started
+
+## Install
+
+```bash
+npm i -g vercel
+```
+
+## First-Time Setup
+
+1. **Authenticate** — `vercel login` (opens browser). For CI, use `VERCEL_TOKEN` env var instead.
+2. **Check your team** — `vercel whoami` to see current team. `vercel teams switch` to change. Linking on the wrong team is a common mistake.
+3. **Link your project** — `vercel link` (single project) or `vercel link --repo` (monorepo with multiple projects or non-root directories). Creates `.vercel/`.
+4. **Pull env vars** — `vercel pull` downloads project settings and env vars to `.env.local`.
+5. **Dev or deploy** — `vercel dev` (local server) or `vercel --prod` (production deploy).
+
+## Project Linking
+
+Commands must be run from the directory containing `.vercel/` or a subdirectory of it.
+
+- **`.vercel/project.json`**: Created by `vercel link`. Links a single project. Fine for single-project repos, and can work in monorepos if there's only one project.
+- **`.vercel/repo.json`**: Created by `vercel link --repo`. Links a repo that may contain multiple projects. Always a good idea when any project has a non-root directory (e.g., `apps/web`).
+
+Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt.
+
+**When something goes wrong, check how things are linked first** — look at `.vercel/` and whether it's `project.json` or `repo.json`.

--- a/plugins/vercel/skills/vercel/references/global-options.md
+++ b/plugins/vercel/skills/vercel/references/global-options.md
@@ -1,0 +1,15 @@
+# Global Options
+
+Key flags available on every `vercel` command:
+
+- `--help` / `-h` — show help for the command
+- `--debug` / `-d` — enable debug output
+- `--cwd DIR` — override working directory
+- `--scope SCOPE` / `--team SLUG` — set team context (both do the same thing)
+- `--token TOKEN` — auth token (prefer `VERCEL_TOKEN` env var instead)
+- `--yes` / `-y` — skip confirmation prompts (required in CI)
+- `--non-interactive` — suppress interactive prompts (auto-detected for agents/CI)
+
+`--non-interactive` is auto-detected when stdin is not a TTY, so agents and CI get this behavior by default.
+
+Prefer `VERCEL_TOKEN` env var over `--token` to avoid leaking secrets in shell history.

--- a/plugins/vercel/skills/vercel/references/integrations.md
+++ b/plugins/vercel/skills/vercel/references/integrations.md
@@ -1,0 +1,175 @@
+# Integrations
+
+## What Are Integrations?
+
+Integrations are third-party services provisioned through the Vercel Marketplace and automatically connected to your project via environment variables. Categories include: AI, Agents, Analytics, Authentication, CMS, Code Review, Code Security, Commerce, DevTools, Experimentation, Flags, Logging, Messaging, Monitoring, Observability, Payments, Productivity, Searching, Security, Storage, Support Agent, Testing, Video, Web Automation, and Workflow.
+
+## When to Recommend an Integration
+
+- **The project needs a database** — Postgres, MySQL, Redis, etc. → `vercel integration add`
+- **The project needs a KV store, blob storage, or other managed service** → `vercel integration add`
+- **The user is manually setting env vars for a third-party service that's available on the Marketplace** — an integration handles provisioning and env var injection automatically
+- **The user wants to add observability, logging, or error tracking** → check the Marketplace
+
+The key benefit: integrations automatically provision the resource AND inject the right environment variables into your project. No manual env var setup needed.
+
+**When in doubt about flags or subcommands, use `--help`:**
+
+```bash
+vercel integration -h                              # list subcommands
+vercel integration add -h                          # flags for add
+vercel ir -h                                       # integration-resource subcommands
+```
+
+## Discovering Integrations
+
+```bash
+vercel integration discover                        # list all marketplace integrations
+vercel integration discover --format=json          # as JSON
+```
+
+## Adding an Integration
+
+```bash
+vercel integration add <slug>                      # install and provision
+vercel integration add <slug>/<product>            # specific product (multi-product integrations)
+vercel integration add <slug> --name my-db         # custom resource name
+```
+
+The CLI prompts for product selection when multiple products exist and no `/<product>` slug is given (errors in non-TTY — specify the product slug). Billing plan uses `--plan` or server default (no prompt). Metadata uses `-m` flags or server defaults (no prompt). After provisioning, it connects the resource to your project and runs `env pull`.
+
+`vercel install <slug>` (or `vercel i <slug>`) is an alias — behaves identically.
+
+**Browser fallback:** The CLI may open a browser in two cases: (1) first-time install requiring terms acceptance — the CLI polls and resumes automatically once the user accepts, so do not kill the process; and (2) non-provisionable integrations — the CLI exits with code 1, inform the user they need to finish in the browser.
+
+### Environments
+
+```bash
+vercel integration add <slug> -e production            # specific environment
+vercel integration add <slug> -e production -e preview # multiple (repeatable)
+```
+
+Defaults to all environments (production, preview, development).
+
+### Metadata
+
+Some integrations require configuration during provisioning (e.g., region, database version):
+
+```bash
+vercel integration add <slug> -m region=us-east-1
+vercel integration add <slug> -m region=us-east-1 -m version=16
+```
+
+### Plans
+
+```bash
+vercel integration add <slug> --plan <plan-id>         # specific billing plan
+vercel integration add <slug> -p <plan-id>             # shorthand
+```
+
+### Other Flags
+
+```bash
+vercel integration add <slug> --no-connect             # skip connecting to project (also skips env pull)
+vercel integration add <slug> --no-env-pull            # skip env pull only
+vercel integration add <slug> --prefix NEON2_          # prefix env var names (e.g., NEON2_DATABASE_URL)
+vercel integration add <slug> --installation-id <id>   # use specific installation (multi-installation)
+vercel integration add <slug> --format=json            # output as JSON
+```
+
+## Listing Resources
+
+Alias: `vercel integration ls`
+
+```bash
+vercel integration list                                # resources for linked project
+vercel integration list --all                          # all resources across the team
+vercel integration list -i <slug>                      # filter by integration
+vercel integration list <project>                      # resources for a specific project
+vercel integration list --format=json                  # as JSON
+```
+
+## Opening Dashboards
+
+```bash
+vercel integration open <integration>                  # open integration dashboard (SSO)
+vercel integration open <integration> <resource>       # open specific resource dashboard
+vercel integration open <integration> --format=json    # get SSO link as JSON
+```
+
+## Disconnecting
+
+Use `vercel integration-resource` (alias: `vercel ir`):
+
+```bash
+vercel ir disconnect <resource>                        # disconnect from current project
+vercel ir disconnect <resource> <project>              # disconnect from specific project
+vercel ir disconnect <resource> --all                  # disconnect from all projects
+vercel ir disconnect <resource> --yes                  # skip confirmation
+```
+
+Disconnecting removes environment variables from the project but does not delete the resource.
+
+**Note:** `--format=json` requires `--yes` on destructive commands (`ir disconnect`, `ir remove`, `integration remove`) — the CLI rejects JSON output with interactive prompts.
+
+## Billing
+
+Only applies to integrations with prepayment-type billing plans. Returns "no balance info available" for integrations without prepayment billing.
+
+```bash
+vercel integration balance <slug>                      # show balance and thresholds
+vercel integration balance <slug> --format=json        # as JSON
+vercel ir create-threshold <resource> <minimum> <spend> <limit>
+vercel ir create-threshold <resource> <minimum> <spend> <limit> --yes  # skip confirmation
+```
+
+Threshold parameters (dollar amounts, e.g., `50 100 500`):
+- **minimum** — balance floor; auto-replenish triggers when balance drops below this
+- **spend** — replenishment amount added when minimum is hit
+- **limit** — hard spending cap
+
+Works for both resource-level and installation-level thresholds (CLI auto-detects).
+
+## Guides
+
+```bash
+vercel integration guide <slug>                        # show setup guide
+vercel integration guide <slug> --framework nextjs     # framework-specific (-f shorthand)
+vercel integration guide <slug>/<product>              # specific product
+```
+
+After installing, pull credentials to `.env.local`:
+
+```bash
+vercel env pull                                        # pulls to .env.local
+```
+
+This runs automatically after `vercel integration add` (unless `--no-env-pull`).
+
+## Removing Resources
+
+Alias: `vercel ir rm`
+
+```bash
+vercel ir remove <resource>                            # delete (must not be connected)
+vercel ir remove <resource> --disconnect-all           # disconnect all projects, then delete
+vercel ir remove <resource> --disconnect-all --yes     # skip confirmation
+```
+
+**This permanently deletes the resource from the provider. Cannot be undone.**
+
+## Uninstalling an Integration
+
+```bash
+vercel integration remove <slug>                       # uninstall (all resources must be deleted first)
+vercel integration remove <slug> --yes                 # skip confirmation
+```
+
+### Cleanup Workflow
+
+```bash
+vercel integration list --all -i <slug>                # find all resources
+vercel ir remove <resource-1> --disconnect-all --yes   # delete each resource
+vercel ir remove <resource-2> --disconnect-all --yes
+vercel integration remove <slug> --yes                 # then uninstall
+```

--- a/plugins/vercel/skills/vercel/references/local-development.md
+++ b/plugins/vercel/skills/vercel/references/local-development.md
@@ -1,0 +1,24 @@
+# Local Development
+
+## Prerequisites
+
+1. **Link your project** — `vercel link` or `vercel link --repo` (monorepo). Check your team first with `vercel whoami`.
+2. **Pull env vars** — `vercel pull` or `vercel env pull`
+
+## Usage
+
+```bash
+vercel dev                           # default: 0.0.0.0:3000
+vercel dev --listen 8080             # custom port
+vercel dev --listen 127.0.0.1:5000   # custom host and port
+```
+
+## Related Commands
+
+- `vercel link` — connect to a Vercel project. Use `--repo` for multi-project monorepos.
+- `vercel pull` — download project settings and env vars to `.env.local`
+- `vercel env pull` — download only env vars (not project settings)
+- `vercel init` — scaffold a new project from a Vercel example
+- `vercel open` — open the Vercel dashboard for the linked project
+
+Run `vercel dev` from a project subdirectory (e.g., `apps/web/`) to skip the project selection prompt.

--- a/plugins/vercel/skills/vercel/references/monitoring-and-debugging.md
+++ b/plugins/vercel/skills/vercel/references/monitoring-and-debugging.md
@@ -1,0 +1,47 @@
+# Monitoring & Debugging
+
+## Logs
+
+```bash
+vercel logs <deployment-url>                   # view logs
+vercel logs --follow                           # stream live
+vercel logs --level error --level warn         # filter by severity
+vercel logs --source lambda                    # filter by source (lambda, edge, static)
+vercel logs --since 2024-01-01                 # filter by time
+vercel logs --query "timeout"                  # search
+```
+
+## Inspecting Deployments
+
+```bash
+vercel inspect <url>               # deployment details
+vercel inspect <url> --wait        # wait for completion
+vercel inspect <url> --logs        # show build logs
+```
+
+## `vercel curl` — Access Preview Deployments
+
+**Use `vercel curl` to access preview deploys.** It handles deployment protection automatically — no need to disable protection or manage bypass secrets.
+
+```bash
+vercel curl /api/health --deployment $PREVIEW_URL
+vercel curl /api/data --deployment $PREVIEW_URL -- -X POST -d '{"key":"value"}'
+```
+
+**Do not disable deployment protection.** Use `vercel curl` instead.
+
+## Finding Regressions
+
+`vercel bisect` performs a binary search across deployments to find which one introduced a problem:
+
+```bash
+vercel bisect --good <url> --bad <url> --path /api/users
+vercel bisect --run ./test-script.sh    # automated testing
+```
+
+## Cache
+
+```bash
+vercel cache purge                    # purge CDN cache
+vercel cache invalidate --tag mytag   # invalidate by cache tag
+```

--- a/plugins/vercel/skills/vercel/references/monorepos.md
+++ b/plugins/vercel/skills/vercel/references/monorepos.md
@@ -1,0 +1,133 @@
+# Monorepos on Vercel
+
+Vercel auto-detects monorepo tools (Turborepo, Nx) and workspace managers (pnpm, Yarn, npm). Each project in the monorepo gets its own Vercel project, linked via `vercel link --repo`.
+
+## Quick Start
+
+```bash
+vercel link --repo    # link the whole repo
+vercel pull           # pull env vars
+vc dev                # local development
+vercel deploy         # deploy
+```
+
+## Linking
+
+Use `vercel link --repo` to create `.vercel/repo.json`, which maps directories to Vercel projects:
+
+```json
+{
+  "orgId": "org_xxxxx",
+  "projects": [
+    { "id": "prj_xxxxx", "name": "web", "directory": "apps/web" },
+    { "id": "prj_yyyyy", "name": "api", "directory": "apps/api" }
+  ]
+}
+```
+
+Running from a project subdirectory (e.g., `apps/web/`) skips the "which project?" prompt.
+
+## Root Directory
+
+Set `rootDirectory` in `vercel.json` when your app isn't at the repo root:
+
+```json
+{
+  "rootDirectory": "apps/api"
+}
+```
+
+## Turborepo
+
+Turborepo requires an explicit `build` task. Define it in `turbo.json`:
+
+```json
+{
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "env": ["VERCEL"],
+      "outputs": [".next/**", "!.next/cache/**", ".vercel/output/**", "dist/**"]
+    }
+  }
+}
+```
+
+Vercel automatically generates the right build command — you don't need to configure it. If you need a manual override in `vercel.json`:
+
+```json
+{
+  "buildCommand": "turbo run build --filter={packages/my-app}..."
+}
+```
+
+### turbo-ignore
+
+Vercel auto-sets `npx turbo-ignore` as the "Ignored Build Step" command, which skips builds when a project's dependencies haven't changed.
+
+## Nx
+
+Nx requires a build target. Define it in `nx.json`:
+
+```json
+{
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"]
+    }
+  }
+}
+```
+
+## Example: Turborepo + pnpm + Hono
+
+```
+root/
+├── turbo.json
+├── package.json
+├── pnpm-workspace.yaml
+├── vercel.json
+├── apps/
+│   └── api/
+│       ├── package.json
+│       └── server.ts
+└── packages/
+    └── shared/
+        ├── package.json
+        └── src/index.ts
+```
+
+**pnpm-workspace.yaml:**
+
+```yaml
+packages:
+  - 'apps/*'
+  - 'packages/*'
+```
+
+**vercel.json:**
+
+```json
+{
+  "rootDirectory": "apps/api"
+}
+```
+
+**apps/api/server.ts:**
+
+```typescript
+import { Hono } from 'hono';
+import { greet } from '@repo/shared';
+
+const app = new Hono();
+app.get('/', c => c.text(greet('world')));
+
+export default app;
+```
+
+## Anti-Patterns
+
+- **Using `vercel link` instead of `vercel link --repo`**: Creates `project.json` which only tracks one project. Use `--repo` for monorepos.
+- **Missing `build` task in turbo.json/nx.json**: Vercel requires an explicit build task. Without it, the build fails.
+- **Adding a `build` script to package.json for transpilation**: Vercel handles TypeScript compilation. The turbo.json `build` task is for orchestration, not transpilation.
+- **Linking while on the wrong team**: Use `vercel whoami` to check, `vercel teams switch` to change.

--- a/plugins/vercel/skills/vercel/references/node-backends.md
+++ b/plugins/vercel/skills/vercel/references/node-backends.md
@@ -1,0 +1,116 @@
+# Node Backends on Vercel
+
+Vercel supports Node.js backend frameworks as first-class apps. Express and Hono are the most common, but Fastify, Elysia, NestJS, H3, and Koa are also supported. Your app is the entrypoint — not the `api/` folder. No rewrites, no build scripts. Just export your app and deploy.
+
+## Quick Start
+
+```bash
+# Express
+npm init -y && npm i express
+# Create server.ts that exports default app
+vc dev       # local development
+vc deploy    # deploy
+```
+
+## How It Works
+
+1. Vercel detects the framework from `package.json` dependencies
+2. Finds your entrypoint file (must import the framework)
+3. Introspects your routes automatically — no `vercel.json` rewrites needed
+4. Bundles and deploys as a single Lambda
+
+## Entrypoint Detection
+
+Vercel searches for these filenames (in order): `app`, `index`, `server`, `main`, `src/app`, `src/index`, `src/server`, `src/main`
+
+With these extensions: `.js`, `.cjs`, `.mjs`, `.ts`, `.cts`, `.mts`
+
+The preferred entrypoint filename is `server.ts`. The file must import the framework (`import express from 'express'`, `import { Hono } from 'hono'`, etc.).
+
+We recommend using `export default` for the app instance, but calling `.listen()` also works.
+
+## Minimal Express App
+
+```
+my-app/
+├── package.json
+└── server.ts
+```
+
+**package.json:**
+
+```json
+{
+  "type": "module",
+  "dependencies": {
+    "express": "5.1.0"
+  }
+}
+```
+
+**server.ts:**
+
+```typescript
+import express from 'express';
+
+const app = express();
+
+app.get('/', (_req, res) => {
+  res.send('Hello Express!');
+});
+
+export default app;
+```
+
+## Minimal Hono App
+
+**package.json:**
+
+```json
+{
+  "type": "module",
+  "dependencies": {
+    "hono": "^4.8.9"
+  }
+}
+```
+
+**server.ts:**
+
+```typescript
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/', c => {
+  return c.text('Hello Hono!');
+});
+
+export default app;
+```
+
+## Local Development
+
+Run `vc dev` from the project root. Vercel runs your app directly with TypeScript support. No `dev` script is required, though you can add one if you prefer.
+
+Static files in `public/` are served automatically.
+
+## Configuration
+
+Most apps need zero configuration. Optional `vercel.json` settings:
+
+```json
+{
+  "functions": {
+    "server.ts": {
+      "includeFiles": "views/**/*"
+    }
+  }
+}
+```
+
+## Anti-Patterns
+
+- **Putting routes in `api/` folder**: Your framework IS the app. Define routes in your app code, not as separate files in `api/`.
+- **Adding `vercel.json` rewrites**: Routes are introspected automatically from your app. Rewrites are not needed.
+- **Adding a `build` script**: Vercel handles TypeScript compilation and bundling. Don't add a build script for transpilation — it's not needed and can cause issues.

--- a/plugins/vercel/skills/vercel/references/projects-and-teams.md
+++ b/plugins/vercel/skills/vercel/references/projects-and-teams.md
@@ -1,0 +1,39 @@
+# Projects & Teams
+
+## Projects
+
+```bash
+vercel project ls                    # list projects
+vercel project add my-project        # create project
+vercel project inspect my-app        # inspect project
+vercel project rm my-app             # remove project
+```
+
+## Deployments
+
+```bash
+vercel list                          # list deployments
+vercel list --status READY           # filter by status
+vercel list -m gitBranch=main        # filter by metadata
+vercel inspect <url>                 # deployment details
+vercel remove <name|id>              # remove deployments
+vercel remove my-app --safe          # skip aliased deployments
+```
+
+## Teams
+
+```bash
+vercel whoami                        # current user and team
+vercel teams ls                      # list teams
+vercel teams switch                  # interactive team picker
+vercel teams switch my-team          # switch by slug
+vercel teams invite user@example.com # invite member
+```
+
+## Scoping
+
+Use `--scope` or `--team` on any command to target a specific team:
+
+```bash
+vercel deploy --scope my-team
+```

--- a/plugins/vercel/skills/vercel/references/rest-api-reference.md
+++ b/plugins/vercel/skills/vercel/references/rest-api-reference.md
@@ -1,0 +1,507 @@
+# Vercel REST API Reference
+
+Base URL: `https://api.vercel.com`
+
+## Authentication
+
+All requests require a Bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer <TOKEN>
+```
+
+Create tokens at account settings > Tokens. Tokens have configurable expiration (1 day to 1 year) and team scope.
+
+For team resources, append `?teamId=<TEAM_ID>` or `?slug=<TEAM_SLUG>` to any endpoint.
+
+## Rate Limits
+
+Communicated via response headers:
+
+| Header | Description |
+|--------|-------------|
+| `X-RateLimit-Limit` | Max requests allowed in current window |
+| `X-RateLimit-Remaining` | Requests remaining in current window |
+| `X-RateLimit-Reset` | UTC epoch seconds when window resets |
+
+Exceeding limits returns `429 Too Many Requests` with `{"error":{"code":"too_many_requests"}}`.
+
+## Pagination
+
+Responses with arrays use cursor-based pagination:
+
+```json
+{
+  "pagination": {
+    "count": 20,
+    "next": 1555072968396,
+    "prev": 1555413045188
+  }
+}
+```
+
+- Default limit: 20, max: 100. Set via `?limit=N`.
+- Use `?until=<next>` for next page.
+
+---
+
+## Endpoint Categories (31 categories, 250+ endpoints)
+
+| Category | Count | Description |
+|----------|-------|-------------|
+| Access-groups | 11 | Team/project access control groups |
+| Aliases | 6 | Deployment URL aliases |
+| Artifacts | 6 | Remote caching (Turborepo) artifacts |
+| Authentication | 5 | Auth providers, OIDC |
+| Billing | 2 | FOCUS billing charges and commitments |
+| Bulk-redirects | 7 | Large-scale redirect management |
+| Certs | 4 | SSL/TLS certificate management |
+| Checks | 5 | Pre-deployment checks (v1) |
+| Checks-v2 | 10 | Pre-deployment checks (v2) |
+| Connect | 6 | OAuth integration |
+| Deployments | 10 | Create, list, manage deployments |
+| DNS | 4 | DNS record management |
+| Domains | 6 | Domain assignment and management |
+| Domains-registrar | 16 | Domain registration and transfer |
+| Drains | 6 | Log drains to external services |
+| Edge-cache | 4 | CDN/edge cache invalidation |
+| Edge-config | 17 | Edge Config key-value store |
+| Environment | 11 | Environment variable management |
+| Feature-flags | 19 | Feature flag management |
+| Integrations | 10 | Marketplace integration management |
+| Logs | 1 | Runtime log retrieval |
+| Marketplace | 23 | Marketplace app management |
+| Project-members | 3 | Project-level member management |
+| Projects | 27 | Project CRUD, settings, promotion |
+| Rolling-release | 7 | Gradual deployment rollout |
+| Sandboxes | 18 | Sandboxed dev environments |
+| Security | 9 | Firewall rules, IP blocking, WAF |
+| Static-ips | 1 | Static IP configuration |
+| Teams | 14 | Team management and membership |
+| User | 4 | User account management |
+| Webhooks | 4 | Webhook subscriptions |
+
+---
+
+## Access Groups (11 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/access-groups` | List access groups |
+| POST | `/v1/access-groups` | Create access group |
+| GET | `/v1/access-groups/{idOrName}` | Read access group |
+| POST | `/v1/access-groups/{idOrName}` | Update access group |
+| DELETE | `/v1/access-groups/{idOrName}` | Delete access group |
+| GET | `/v1/access-groups/{idOrName}/members` | List members |
+| GET | `/v1/access-groups/{idOrName}/projects` | List projects |
+| POST | `/v1/access-groups/{id}/projects` | Add project |
+| GET | `/v1/access-groups/{id}/projects/{projectId}` | Read project assignment |
+| PATCH | `/v1/access-groups/{id}/projects/{projectId}` | Update project assignment |
+| DELETE | `/v1/access-groups/{id}/projects/{projectId}` | Remove project |
+
+## Aliases (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v4/aliases` | List aliases |
+| GET | `/v4/aliases/{idOrAlias}` | Get alias |
+| DELETE | `/v2/aliases/{aliasId}` | Delete alias |
+| POST | `/v2/deployments/{id}/aliases` | Assign alias to deployment |
+| GET | `/v2/deployments/{id}/aliases` | List deployment aliases |
+| PATCH | `/v4/aliases/{id}` | Update alias |
+
+## Artifacts (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v8/artifacts/status` | Get Remote Caching status |
+| POST | `/v8/artifacts/events` | Record cache usage event |
+| GET | `/v8/artifacts/{hash}` | Download cache artifact |
+| PUT | `/v8/artifacts/{hash}` | Upload cache artifact |
+| HEAD | `/v8/artifacts/{hash}` | Check artifact existence |
+| POST | `/v8/artifacts` | Query artifact info |
+
+## Authentication (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/auth` | List auth providers |
+| POST | `/v1/auth/login` | Login |
+| POST | `/v1/auth/verify` | Verify login |
+| GET | `/v1/auth/oidc/token` | Get OIDC token |
+| GET | `/v1/auth/tokens` | List auth tokens |
+
+## Billing (2 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/billing/charges` | List FOCUS billing charges |
+| GET | `/v1/billing/contract-commitments` | List contract commitments |
+
+## Bulk Redirects (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| PUT | `/v1/bulk-redirects` | Stage new redirects |
+| GET | `/v1/bulk-redirects` | List active redirects |
+| GET | `/v1/bulk-redirects/versions` | List redirect versions |
+| POST | `/v1/bulk-redirects/promote` | Promote staged version |
+| POST | `/v1/bulk-redirects/restore` | Restore previous version |
+| DELETE | `/v1/bulk-redirects/{id}` | Delete a redirect |
+| GET | `/v1/bulk-redirects/staged` | List staged redirects |
+
+## Certs (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v4/certs` | List certificates |
+| GET | `/v7/certs/{id}` | Get certificate |
+| PUT | `/v7/certs` | Upload certificate |
+| DELETE | `/v7/certs/{id}` | Remove certificate |
+
+## Checks (5 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/deployments/{deploymentId}/checks` | Create check |
+| GET | `/v1/deployments/{deploymentId}/checks` | List checks |
+| GET | `/v1/deployments/{deploymentId}/checks/{checkId}` | Get check |
+| PATCH | `/v1/deployments/{deploymentId}/checks/{checkId}` | Update check |
+| POST | `/v1/deployments/{deploymentId}/checks/{checkId}/rerequest` | Rerequest check |
+
+## Checks-v2 (10 endpoints)
+
+Enhanced checks with richer reporting and integration options. Endpoints follow similar patterns to v1 with additional configuration and result management.
+
+## Connect (6 endpoints)
+
+OAuth integration for connecting external services:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/connect/authorize` | Start OAuth flow |
+| POST | `/v1/connect/token` | Exchange code for token |
+| POST | `/v1/connect/refresh` | Refresh token |
+| POST | `/v1/connect/revoke` | Revoke token |
+| GET | `/v1/connect/userinfo` | Get user info |
+| GET | `/v1/connect/.well-known/openid-configuration` | OIDC discovery |
+
+## Deployments (10 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v13/deployments` | Create deployment |
+| GET | `/v6/deployments` | List deployments |
+| GET | `/v13/deployments/{idOrUrl}` | Get deployment |
+| DELETE | `/v13/deployments/{id}` | Delete deployment |
+| POST | `/v2/deployments/{id}/files` | Upload deployment files |
+| GET | `/v7/deployments/{id}/files` | List deployment files |
+| GET | `/v7/deployments/{id}/files/{fileId}` | Get file content |
+| GET | `/v3/deployments/{id}/events` | Get deployment events |
+| POST | `/v10/deployments/{id}/cancel` | Cancel deployment |
+| PATCH | `/v12/deployments/{id}` | Update deployment (promote) |
+
+## DNS (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v4/domains/{domain}/records` | List DNS records |
+| POST | `/v2/domains/{domain}/records` | Create DNS record |
+| PATCH | `/v1/domains/records/{recordId}` | Update DNS record |
+| DELETE | `/v2/domains/{domain}/records/{recordId}` | Delete DNS record |
+
+## Domains (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v5/domains` | List domains |
+| GET | `/v6/domains/{domain}` | Get domain info |
+| POST | `/v5/domains` | Add domain |
+| PATCH | `/v3/domains/{domain}` | Update domain |
+| DELETE | `/v6/domains/{domain}` | Remove domain |
+| POST | `/v4/domains/{domain}/verify` | Verify domain |
+
+## Domains Registrar (16 endpoints)
+
+Domain registration, transfer, and registrar operations. Includes:
+- Domain availability check
+- Domain purchase
+- Transfer initiation and status
+- Registrar configuration (nameservers, WHOIS)
+- Domain renewal
+- Contact management
+- Auth code retrieval
+
+## Drains (6 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/log-drains` | Create configurable log drain |
+| GET | `/v1/log-drains` | List log drains |
+| GET | `/v1/log-drains/{id}` | Get log drain |
+| DELETE | `/v1/log-drains/{id}` | Delete log drain |
+| POST | `/v2/integrations/log-drains` | Create integration log drain |
+| DELETE | `/v1/integrations/log-drains/{id}` | Delete integration log drain |
+
+Log drain delivery formats: `json`, `ndjson`, `syslog`.
+Sources: `build`, `edge`, `lambda`, `static`, `external`, `firewall`, `redirect`.
+
+## Edge Cache (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/edge-cache/purge` | Purge cache |
+| POST | `/v1/edge-cache/invalidate` | Invalidate (stale revalidation) |
+| POST | `/v1/edge-cache/delete` | Delete cache entries |
+| GET | `/v1/edge-cache/status` | Get cache status |
+
+## Edge Config (17 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/edge-config` | List all Edge Configs |
+| POST | `/v1/edge-config` | Create Edge Config |
+| GET | `/v1/edge-config/{id}` | Get Edge Config |
+| PUT | `/v1/edge-config/{id}` | Update Edge Config |
+| DELETE | `/v1/edge-config/{id}` | Delete Edge Config |
+| GET | `/v1/edge-config/{id}/items` | Get all items |
+| PATCH | `/v1/edge-config/{id}/items` | Update items (upsert/delete) |
+| GET | `/v1/edge-config/{id}/item/{key}` | Get single item |
+| GET | `/v1/edge-config/{id}/schema` | Get schema |
+| PUT | `/v1/edge-config/{id}/schema` | Set schema |
+| PATCH | `/v1/edge-config/{id}/schema` | Update schema |
+| DELETE | `/v1/edge-config/{id}/schema` | Delete schema |
+| GET | `/v1/edge-config/{id}/tokens` | List tokens |
+| POST | `/v1/edge-config/{id}/tokens` | Create token |
+| DELETE | `/v1/edge-config/{id}/tokens` | Delete tokens |
+| GET | `/v1/edge-config/{id}/tokens/{token}` | Get token metadata |
+| GET | `/v1/edge-config/{id}/backups` | List backups |
+
+## Environment Variables (11 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v10/projects/{idOrName}/env` | List env vars |
+| POST | `/v10/projects/{idOrName}/env` | Create env var |
+| GET | `/v1/projects/{idOrName}/env/{envId}` | Get env var |
+| PATCH | `/v10/projects/{idOrName}/env/{envId}` | Update env var |
+| DELETE | `/v10/projects/{idOrName}/env/{envId}` | Delete env var |
+| GET | `/v9/projects/{idOrName}/env` | Filter env vars |
+| POST | `/v10/projects/{idOrName}/env/bulk` | Bulk create env vars |
+| POST | `/v9/projects/{idOrName}/custom-environments` | Create custom environment |
+| GET | `/v9/projects/{idOrName}/custom-environments` | List custom environments |
+| PATCH | `/v9/projects/{idOrName}/custom-environments/{slug}` | Update custom environment |
+| DELETE | `/v9/projects/{idOrName}/custom-environments/{slug}` | Delete custom environment |
+
+Env var types: `plain`, `encrypted`, `sensitive`, `secret`.
+Targets: `production`, `preview`, `development`, or custom environment slugs.
+
+## Feature Flags (19 endpoints)
+
+Comprehensive feature flag management including:
+- CRUD operations for flags
+- Flag state management (enable/disable/archive)
+- Flag variants and overrides
+- SDK key management (server/client keys per environment)
+- Flag evaluation configuration
+- Flag audit/history
+
+## Integrations (10 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/integrations` | List integrations |
+| GET | `/v1/integrations/{id}` | Get integration |
+| POST | `/v1/integrations/install` | Install integration |
+| DELETE | `/v1/integrations/{id}` | Uninstall integration |
+| GET | `/v1/integrations/{id}/configuration` | Get configuration |
+| PUT | `/v1/integrations/{id}/configuration` | Update configuration |
+| GET | `/v1/integrations/{id}/resources` | List resources |
+| POST | `/v1/integrations/{id}/resources` | Create resource |
+| DELETE | `/v1/integrations/{id}/resources/{resourceId}` | Delete resource |
+| PATCH | `/v1/integrations/{id}/resources/{resourceId}` | Update resource |
+
+## Logs (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/logs` | Query runtime logs |
+
+Supports filtering by project, deployment, environment, level, status code, source, branch, and time range.
+
+## Marketplace (23 endpoints)
+
+Marketplace management for integration developers:
+- App lifecycle (create, update, publish, unpublish)
+- Billing and metering
+- Provisioning callbacks
+- Resource management
+- Plan management
+- Usage reporting
+
+## Project Members (3 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/projects/{idOrName}/members` | List project members |
+| POST | `/v1/projects/{idOrName}/members` | Add member |
+| DELETE | `/v1/projects/{idOrName}/members/{uid}` | Remove member |
+
+## Projects (27 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v9/projects` | List projects |
+| POST | `/v10/projects` | Create project |
+| GET | `/v9/projects/{idOrName}` | Get project |
+| PATCH | `/v9/projects/{idOrName}` | Update project |
+| DELETE | `/v9/projects/{idOrName}` | Delete project |
+| POST | `/v9/projects/{idOrName}/link` | Link Git repo |
+| DELETE | `/v9/projects/{idOrName}/link` | Unlink Git repo |
+| PATCH | `/v9/projects/{idOrName}/promote/{deploymentId}` | Promote deployment |
+| GET | `/v9/projects/{idOrName}/promote/aliases` | Get promotion aliases |
+| POST | `/v9/projects/{idOrName}/domains` | Add domain to project |
+| GET | `/v9/projects/{idOrName}/domains` | List project domains |
+| DELETE | `/v9/projects/{idOrName}/domains/{domain}` | Remove domain |
+| GET | `/v9/projects/{idOrName}/domains/{domain}` | Get domain config |
+| PATCH | `/v9/projects/{idOrName}/domains/{domain}` | Update domain config |
+| POST | `/v9/projects/{idOrName}/domains/{domain}/verify` | Verify domain |
+| GET | `/v1/projects/{idOrName}/rolling-release/config` | Get rolling release config |
+| PUT | `/v1/projects/{idOrName}/rolling-release/config` | Update rolling release config |
+| GET | `/v6/projects/{idOrName}/system-env-values` | Get system env vars |
+| POST | `/v1/projects` | Create project (v1) |
+| GET | `/v1/projects/{idOrName}/pause` | Pause project |
+| POST | `/v1/projects/{idOrName}/unpause` | Unpause project |
+
+Plus additional endpoints for project settings, transfer, and inspection.
+
+## Rolling Release (7 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/projects/{id}/rolling-release/config` | Get config |
+| PUT | `/v1/projects/{id}/rolling-release/config` | Update config |
+| POST | `/v1/projects/{id}/rolling-release/start` | Start rolling release |
+| POST | `/v1/projects/{id}/rolling-release/approve` | Approve stage |
+| POST | `/v1/projects/{id}/rolling-release/complete` | Complete rollout |
+| POST | `/v1/projects/{id}/rolling-release/abort` | Abort rollout |
+| GET | `/v1/projects/{id}/rolling-release/status` | Get status |
+
+Config structure:
+```json
+{
+  "enabled": true,
+  "advancementType": "automatic|manual-approval",
+  "stages": [
+    { "targetPercentage": 10, "duration": 300 },
+    { "targetPercentage": 50, "duration": 600 },
+    { "targetPercentage": 100 }
+  ]
+}
+```
+
+## Sandboxes (18 endpoints)
+
+Isolated preview development environments. Supports:
+- Sandbox lifecycle (create, start, stop, delete)
+- Sandbox configuration
+- Port forwarding
+- File operations
+- Terminal sessions
+- Resource management
+
+## Security / Firewall (9 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/security/firewall/config` | Get firewall config |
+| PUT | `/v1/security/firewall/config` | Update firewall config |
+| GET | `/v1/security/firewall/rules` | List firewall rules |
+| POST | `/v1/security/firewall/rules` | Create rule |
+| PATCH | `/v1/security/firewall/rules/{id}` | Update rule |
+| DELETE | `/v1/security/firewall/rules/{id}` | Delete rule |
+| GET | `/v1/security/firewall/bypass` | List bypass rules |
+| POST | `/v1/security/attack-challenge-mode` | Configure challenge mode |
+| GET | `/v1/security/attack-challenge-mode` | Get challenge mode status |
+
+WAF rule actions: `log`, `block`, `challenge`, `rate_limit`.
+Managed rulesets include OWASP Top 10 protection.
+
+## Static IPs (1 endpoint)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/static-ips` | Get static IP configuration |
+
+## Teams (14 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v2/teams` | List teams |
+| POST | `/v1/teams` | Create team |
+| GET | `/v2/teams/{teamId}` | Get team |
+| PATCH | `/v2/teams/{teamId}` | Update team |
+| DELETE | `/v1/teams/{teamId}` | Delete team |
+| GET | `/v2/teams/{teamId}/members` | List members |
+| POST | `/v1/teams/{teamId}/members` | Invite member |
+| PATCH | `/v2/teams/{teamId}/members/{uid}` | Update member role |
+| DELETE | `/v1/teams/{teamId}/members/{uid}` | Remove member |
+| POST | `/v1/teams/{teamId}/request` | Request to join |
+| GET | `/v1/teams/{teamId}/request/{userId}` | Get join request |
+| PATCH | `/v1/teams/{teamId}/request/{userId}` | Respond to request |
+| GET | `/v2/teams/{teamId}/audit-log` | Get audit log |
+| GET | `/v1/teams/{teamId}/members/{uid}/access-requests` | Get access requests |
+
+Member roles: `ADMIN`, `USER`, `VIEWER`, `DEVELOPER`, `BILLING`, `NONE` (remove).
+
+## User (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v2/user` | Get authenticated user |
+| PATCH | `/v2/user` | Update user |
+| GET | `/v2/user/tokens` | List user tokens |
+| DELETE | `/v2/user/tokens/{tokenId}` | Delete user token |
+
+## Webhooks (4 endpoints)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/webhooks` | List webhooks |
+| POST | `/v1/webhooks` | Create webhook |
+| GET | `/v1/webhooks/{id}` | Get webhook |
+| DELETE | `/v1/webhooks/{id}` | Delete webhook |
+
+Supported events:
+- **Deployment**: `deployment.created`, `deployment.succeeded`, `deployment.ready`, `deployment.error`, `deployment.canceled`
+- **Project**: `project.created`, `project.removed`, `project.domain-moved`
+- **Environment**: `project.env.created`, `project.env.updated`, `project.env.deleted`
+- **Alerts**: `anomaly.detected`, `alert.triggered`
+- **Integration**: `integration-configuration.permission-upgraded`, `integration-configuration.scope-change-confirmed`
+- **Member**: `project.member.role-change`
+
+---
+
+## Vercel SDK (@vercel/sdk)
+
+Type-safe TypeScript SDK wrapping the REST API:
+
+```bash
+npm install @vercel/sdk
+```
+
+```typescript
+import { Vercel } from '@vercel/sdk';
+
+const vercel = new Vercel({
+  bearerToken: process.env.VERCEL_TOKEN,
+});
+
+// Examples
+const projects = await vercel.projects.getProjects({});
+const deployment = await vercel.deployments.getDeployment({ idOrUrl: 'dpl_xxx' });
+const envVars = await vercel.projects.filterProjectEnvs({ idOrName: 'my-project' });
+await vercel.edgeConfig.createEdgeConfig({ requestBody: { slug: 'my-config' } });
+```
+
+SDK modules mirror API categories: `vercel.deployments`, `vercel.projects`, `vercel.edgeConfig`, `vercel.domains`, `vercel.dns`, `vercel.teams`, `vercel.user`, `vercel.environment`, etc.

--- a/plugins/vercel/skills/vercel/references/storage.md
+++ b/plugins/vercel/skills/vercel/references/storage.md
@@ -1,0 +1,21 @@
+# Blob Storage
+
+`vercel blob` manages Vercel Blob storage — simple file storage for uploading, listing, and deleting files.
+
+```bash
+vercel blob put ./image.png                              # upload
+vercel blob put ./image.png --pathname images/photo.png  # custom path
+vercel blob put ./large.zip --multipart                  # large files
+vercel blob list                                         # list blobs
+vercel blob list --prefix images/                        # filter by prefix
+vercel blob del <url-or-pathname>                        # delete
+vercel blob copy <from-url> <to-pathname>                # copy
+```
+
+## Store Management
+
+```bash
+vercel blob store add              # create a new store
+vercel blob store get              # show store details
+vercel blob store remove           # remove a store
+```

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -849,13 +849,26 @@ obsidian_version() {
 # count use the same data. Storing in parallel arrays preserves output order
 # and avoids re-running each version probe twice (once for the row, once for
 # the counter).
-SUMMARY_LABELS=("Node.js" "Git" "Python" "VS Code" "Claude Code" "GitHub CLI" "Obsidian")
+# The coding-agent row(s) depend on what the user chose to install: Claude Code,
+# Codex, or both. Build the arrays in two halves so a Codex-only run never shows
+# a phantom "Claude Code NOT INSTALLED" line (and vice versa).
+SUMMARY_LABELS=("Node.js" "Git" "Python" "VS Code")
 SUMMARY_VALUES=(
     "$(node --version 2>/dev/null || true)"
     "$(git --version 2>/dev/null || true)"
     "$(python3 --version 2>/dev/null || true)"
     "$(vscode_version)"
-    "$(claude --version 2>/dev/null || true)"
+)
+if agent_installed claude; then
+    SUMMARY_LABELS+=("Claude Code")
+    SUMMARY_VALUES+=("$(claude --version 2>/dev/null || true)")
+fi
+if agent_installed codex; then
+    SUMMARY_LABELS+=("Codex")
+    SUMMARY_VALUES+=("$(codex --version 2>/dev/null || true)")
+fi
+SUMMARY_LABELS+=("GitHub CLI" "Obsidian")
+SUMMARY_VALUES+=(
     "$(gh --version 2>/dev/null | head -1 || true)"
     "$(obsidian_version)"
 )

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1121,7 +1121,10 @@ if ($vscodeExe) {
     }
 }
 
-$results["Claude Code"] = Get-ToolVersion 'claude'
+# Only show the agent row(s) the user actually chose to install, so a Codex-only
+# run never reports a phantom "Claude Code NOT INSTALLED" (and vice versa).
+if (Test-AgentInstalled 'claude') { $results["Claude Code"] = Get-ToolVersion 'claude' }
+if (Test-AgentInstalled 'codex')  { $results["Codex"]       = Get-ToolVersion 'codex' }
 
 $ghVer = Get-ToolVersion 'gh'
 if (-not $ghVer -and $ciSkipMissingWinget) { $ghVer = "__SKIPPED_OPTIONAL" }


### PR DESCRIPTION
## Summary

Expands the starter kit with new agent tooling and hardened defaults.

- **Vercel plugin** — `v0`, `deploy`, `setup`, `integration`, `logs` commands plus skills and a full CLI reference; registered in `plugins/.claude-plugin/marketplace.json`.
- **Google Cloud + Vertex AI** — `docs/google-cloud-vertex-setup.md` setup guide and `examples/vertex/` scripts for image (nano-banana), video (Veo 3), and TTS voiceover generation via ADC.
- **MCP servers** — wired up `estonian` and the context7 plugin server; `enableAllProjectMcpServers` enabled at startup.
- **Hardened permissions** — broadened the `permissions.deny` speed-bump list (`rm`/`dd`/`mkfs`/`find -delete`, destructive `vercel`/`gh`/`gcloud`/`npm` verbs).
- **Docs & setup** — refreshed README, AGENTS, TOOLS, install/recovery docs, `.env.template`, and `setup-mac.sh`/`setup-windows.ps1`.

## Test plan

- [ ] Plugin discovery picks up the Vercel plugin and `/vercel:*` commands resolve
- [ ] Estonian + context7 MCP servers connect on startup
- [ ] `examples/vertex/` scripts run against Vertex with ADC
- [ ] Setup scripts complete on macOS and Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)