### PR TITLE
chore: refresh docs, install scripts, and CI tooling

### DIFF
--- a/.github/scripts/lint-ascii.py
+++ b/.github/scripts/lint-ascii.py
@@ -15,10 +15,13 @@
 # Approximation:
 #   The trailing-`#`-comment detection tracks single-line "..." and '...'
 #   quote state. It does NOT model multi-line PowerShell here-strings
-#   (@"..."@ / @'...'@) or bash heredocs. Those tolerate stray quotes
-#   internally, but our rule treats their contents as code anyway, which
-#   is fine: the enforced rule (no non-ASCII outside `#`) is a strict
-#   superset of "no non-ASCII in a place that breaks PowerShell parsing".
+#   (@"..."@ / @'...'@) or bash heredocs, nor the bash escaped-apostrophe
+#   idiom '...'\''...' (close, escaped quote, reopen), which can leave the
+#   quote tracker in the wrong state for a trailing comment on that line.
+#   Those tolerate stray quotes internally, but our rule treats their
+#   contents as code anyway, which is fine: the enforced rule (no non-ASCII
+#   outside `#`) is a strict superset of "no non-ASCII in a place that
+#   breaks PowerShell parsing".
 #
 # Exit codes:
 #   0 - all scripts clean

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,9 +40,9 @@ jobs:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
-
+      # No Autobuild step: the matrix scans interpreted/config languages
+      # (actions), which CodeQL analyzes directly. Add Autobuild back only if
+      # you add a compiled language (cpp, csharp, go, java-kotlin, swift).
       - name: Perform analysis
         uses: github/codeql-action/analyze@v4
         with:

--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -402,8 +402,9 @@ setup script, or fall back to the official installer URL):
 - **Node.js**: download the LTS `.pkg` / `.msi` from `https://nodejs.org/`
 - **Git**: `xcode-select --install` (Mac), `winget install Git.Git` (Win)
 
-If a tool is at the wrong version (e.g. Node < 20), tell the user, suggest
-upgrading, and offer to do it. Don't silently overwrite system tools.
+If a tool is at the wrong version (e.g. Node < 22 — Phase 1 pins Node 22 LTS),
+tell the user, suggest upgrading, and offer to do it. Don't silently overwrite
+system tools.
 
 ### 3. GitHub bootstrap — give the user a real first repo
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ installs each one **if you say yes**:
 | Vercel CLI (`vercel`) | Deploy apps and use v0 to generate UIs. |
 | Google Cloud CLI (`gcloud`) | Run the Vertex AI image, video, and voiceover examples. |
 
-Your agent can also set up a knowledge base (Obsidian vault) and Chrome DevTools
-(browser control) in Phase 2 — see those sections below.
+Your agent can also set up a knowledge base (Obsidian vault — see the section
+below) and finish enabling Chrome DevTools browser control in Phase 2 (the MCP
+server is pre-connected; Phase 2 turns on Chrome's remote debugging — see
+[`docs/chrome-devtools-mcp-setup.md`](docs/chrome-devtools-mcp-setup.md)).
 
 ## What's already wired up
 

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -68,7 +68,7 @@ corporate firewall, a Wi-Fi captive portal, or VPN. Try in this order:
 
 ---
 
-## 4. "GitHub auth fails" (Phase 2 step 6b)
+## 4. "GitHub auth fails" (Phase 2 step 3b)
 
 **Symptom:** Claude is walking you through `gh auth login` and something
 goes wrong — the browser doesn't open, the one-time code expired, or
@@ -104,7 +104,7 @@ where it stopped.
 
 ---
 
-## 5. "GitHub repo creation fails" (Phase 2 step 6c)
+## 5. "GitHub repo creation fails" (Phase 2 step 3c)
 
 **Symptom:** `gh repo create` errors out, or the repo is created but the
 push didn't land on `origin/main`.

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -20,7 +20,7 @@ here, it isn't wired in by default.
 | Knowledge base | `.claude/knowledge-base.local.md` (gitignored) | Vault path config — read, never hardcode |
 | Project rules | `CLAUDE.md` | Always-loaded context + conventions |
 | Recovery / handoff | `INSTALL_FOR_AGENTS.md`, `RECOVERY.md` | Phase 2 setup + repair flows |
-| CI | `.github/workflows/*.yml` | bootstrap-e2e, handoff-e2e, install-smoke-test, codeql |
+| CI | `.github/workflows/*.yml` | agent-selection-test, bootstrap-e2e, handoff-e2e, install-smoke-test, codeql |
 
 No local `hooks/`, `commands/`, `agents/`, or `skills/` directories exist in
 `.claude/`. Slash commands and skills come from plugins — including the
@@ -80,7 +80,8 @@ From `extraKnownMarketplaces` in `.claude/settings.json`. Browse with
 | **superpowers-marketplace** | `obra/superpowers-marketplace` | yes | none — brainstorming, writing plans, parallel agents, TDD, systematic debugging, git worktrees |
 | **addy-agent-skills** | `addyosmani/agent-skills` | yes | none — a focused set of high-quality agent skills |
 
-All four above are **registered only** — browse and install via `/plugins`. See
+The marketplaces showing **none** above are **registered only** — browse and
+install via `/plugins`; the others ship the default-enabled plugins listed. See
 `marketplace-plugins.md` for the full per-marketplace plugin catalog.
 
 ---
@@ -181,12 +182,14 @@ Not invokable from chat, but agents may need to know they exist.
 | `install.sh` / `install.ps1` | Phase 1 — clone + extract starter kit |
 | `setup-mac.sh` / `setup-windows.ps1` | Phase 2 — install Claude Code, wire MCP |
 | `.vscode/run-handoff.{sh,ps1}` | One-shot Phase 1→2 handoff prompt opener |
+| `.github/workflows/agent-selection-test.yml` | Agent-selection (claude / codex / both) test |
 | `.github/workflows/bootstrap-e2e.yml` | E2E bootstrap test |
 | `.github/workflows/handoff-e2e.yml` | Handoff flow E2E test |
 | `.github/workflows/install-smoke-test.yml` | Cross-platform install smoke test |
 | `.github/workflows/codeql.yml` | CodeQL static analysis |
 | `.github/scripts/lint-ascii.py` | Enforce ASCII-only in shipped scripts |
 | `tests/handoff/` | Handoff flow fixtures |
+| `tests/registry/` | Workspace-registry library unit tests |
 | `cache/` | Runtime scratch (gitignored except `README.md`) |
 | `plugins/vercel/` | Bundled Vercel + v0 plugin (skills, commands, references) |
 | `examples/vertex/` | Runnable image + video + voiceover scripts (`out/` gitignored) |

--- a/docs/chrome-devtools-mcp-setup.md
+++ b/docs/chrome-devtools-mcp-setup.md
@@ -179,7 +179,7 @@ and it just works on Chrome 144+**.
 | **Performance** | `performance_start_trace`, `performance_stop_trace`, `performance_analyze_insight` | Lighthouse-style perf profiling |
 | **Audit** | `lighthouse_audit` | Full Lighthouse run |
 | **Device emulation** | `emulate`, `resize_page` | Mobile / network throttling |
-| **Memory** | `take_memory_snapshot` | Leak hunting |
+| **Memory** | `take_heapsnapshot` | Leak hunting |
 | **Dialogs** | `handle_dialog` | Confirm/dismiss alerts |
 | **Wait** | `wait_for` | Pause until selector / text appears |
 
@@ -210,7 +210,7 @@ evaluate_script { function: "() => document.cookie" }
 **Run Lighthouse on a page:**
 
 ```text
-navigate_page { url: "https://elnora.ai" }
+navigate_page { url: "https://example.com" }
 lighthouse_audit
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -159,7 +159,7 @@ fails" or "GitHub repo creation fails."
 
 ## Getting help
 
-- **Claude Code documentation**: https://docs.anthropic.com/en/docs/claude-code
+- **Claude Code documentation**: https://code.claude.com/docs/en/overview
 - **Claude Code issues**: https://github.com/anthropics/claude-code/issues
 - **Anthropic support**: https://support.anthropic.com
 - **Codex documentation & issues**: https://github.com/openai/codex

--- a/examples/vertex/generate_video_veo.py
+++ b/examples/vertex/generate_video_veo.py
@@ -32,6 +32,12 @@ def main() -> int:
     if not os.environ.get("GOOGLE_CLOUD_PROJECT"):
         print("Set GOOGLE_CLOUD_PROJECT to your own GCP project ID.", file=sys.stderr)
         return 2
+    location = os.environ.get("GOOGLE_CLOUD_LOCATION", "").strip()
+    if not location or location.lower() == "global":
+        print("Veo needs a REGIONAL location, not 'global'. Set GOOGLE_CLOUD_LOCATION "
+              "to a region like us-central1 (see docs/google-cloud-vertex-setup.md).",
+              file=sys.stderr)
+        return 2
 
     try:
         from google import genai

--- a/examples/vertex/generate_voiceover_tts.py
+++ b/examples/vertex/generate_voiceover_tts.py
@@ -47,6 +47,10 @@ def main() -> int:
     parser.add_argument("--rate", type=float, default=1.0, help="Speaking rate (0.25–4.0)")
     args = parser.parse_args()
 
+    if not 0.25 <= args.rate <= 4.0:
+        print(f"--rate must be between 0.25 and 4.0 (got {args.rate}).", file=sys.stderr)
+        return 2
+
     text = " ".join(args.text).strip() or "Welcome to the hackathon. Let's build something."
     project = os.environ.get("GOOGLE_CLOUD_PROJECT")
     if not project:

--- a/install.ps1
+++ b/install.ps1
@@ -247,7 +247,7 @@ function Get-NormAgent($v) { ($v -replace '\s','').ToLower() }
 
 if (-not [string]::IsNullOrWhiteSpace($env:ELNORA_AGENT)) {
     $Agent = Get-NormAgent $env:ELNORA_AGENT
-} else {
+} elseif ([Environment]::UserInteractive -and $Host.UI.RawUI) {
     Write-Host "Which coding agent do you want to use?"
     Write-Host "  1) Claude Code   (Anthropic; needs a Claude Pro/Max plan or API key)"
     Write-Host "  2) Codex         (OpenAI; needs a ChatGPT Plus/Pro plan or API key)"
@@ -263,6 +263,11 @@ if (-not [string]::IsNullOrWhiteSpace($env:ELNORA_AGENT)) {
         else { Write-Host "  [!] Enter 1, 2, or 3 (or claude / codex / both)." -ForegroundColor Yellow }
     }
     Write-Host ""
+} else {
+    # Non-interactive with no $env:ELNORA_AGENT (piped/headless run) -- default
+    # to Claude Code instead of blocking on Read-Host, mirroring install.sh's
+    # /dev/tty gate.
+    $Agent = "claude"
 }
 
 if ($Agent -notin @("claude","codex","both")) {
@@ -272,7 +277,7 @@ if ($Agent -notin @("claude","codex","both")) {
 if ($Agent -eq "both") {
     if (-not [string]::IsNullOrWhiteSpace($env:ELNORA_HANDOFF_AGENT)) {
         $HandoffAgent = Get-NormAgent $env:ELNORA_HANDOFF_AGENT
-    } else {
+    } elseif ([Environment]::UserInteractive -and $Host.UI.RawUI) {
         Write-Host "You're installing both. Which one should finish setup right now?"
         Write-Host "  1) Claude Code"
         Write-Host "  2) Codex"
@@ -287,6 +292,9 @@ if ($Agent -eq "both") {
             else { Write-Host "  [!] Enter 1 or 2 (or claude / codex)." -ForegroundColor Yellow }
         }
         Write-Host ""
+    } else {
+        # Non-interactive with no $env:ELNORA_HANDOFF_AGENT -- default to Claude.
+        $HandoffAgent = "claude"
     }
 } else {
     $HandoffAgent = $Agent
@@ -368,8 +376,10 @@ if (Test-Path $TargetDir) {
     } else {
         Remove-Item -Path $stash -Recurse -Force -ErrorAction SilentlyContinue
     }
-    Write-Host "Wiping for a fresh install (system tools like Claude, Node, Python are kept)..." -ForegroundColor Gray
-    Remove-Item -Path $TargetDir -Recurse -Force
+    # NOTE: we do NOT wipe $TargetDir here. The wipe happens only AFTER the
+    # new copy has downloaded and verified (see below), so a failed download
+    # on flaky conference/hotel wifi can never leave the user with no
+    # workspace -- and no stashed user data -- at all.
 }
 
 Write-Host "Downloading starter kit zip..." -ForegroundColor Green
@@ -401,6 +411,15 @@ try {
     }
 
     New-Item -ItemType Directory -Path (Split-Path $TargetDir -Parent) -Force -ErrorAction SilentlyContinue | Out-Null
+    # The fresh copy is downloaded and verified -- only now is it safe to
+    # remove the previous install and swap the new one in. Doing the wipe
+    # here (not before the download) means a failed download leaves the
+    # existing workspace untouched. System tools like Claude, Node, Python
+    # live outside $TargetDir and are never touched.
+    if (Test-Path $TargetDir) {
+        Write-Host "Wiping previous install for a fresh copy (system tools are kept)..." -ForegroundColor Gray
+        Remove-Item -Path $TargetDir -Recurse -Force
+    }
     Move-Item -Path $extracted -Destination $TargetDir -Force
     Write-Host "Extracted to $TargetDir" -ForegroundColor Green
 
@@ -427,8 +446,7 @@ try {
     # `throw` instead of `exit 1`: this script is invoked via `irm ... | iex`,
     # which runs in the caller's scope. `exit` would terminate the caller's
     # shell/parent script silently; `throw` surfaces as a catchable error and
-    # still halts this installer if uncaught. Same reasoning as Bug 2 in the
-    # elnora-cli handoff doc.
+    # still halts this installer if uncaught.
     throw "Starter kit bootstrap: failed to download from $zipUrl ($($_.Exception.Message))"
 } finally {
     if (Test-Path $zipPath)       { Remove-Item $zipPath -Force -ErrorAction SilentlyContinue }
@@ -476,8 +494,16 @@ if (Test-Path -LiteralPath $installForAgentsPath) {
     Write-Host "  Wrote integrity marker (.elnora-ai-agent-hackathon-starter-kit-marker)." -ForegroundColor Gray
 }
 
-# Bypass execution policy for this process only so setup-windows.ps1 runs
-# without requiring the user to set it manually (as the older flow did).
-Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+# Bypass execution policy for this process so setup-windows.ps1 runs without
+# the user setting it manually (as the older flow did). On GPO-managed/corporate
+# machines a MachinePolicy/UserPolicy can override the process scope and make
+# this throw under $ErrorActionPreference='Stop', so catch it and continue --
+# the launch below passes -ExecutionPolicy Bypass explicitly, which works even
+# when the policy change is blocked or a downloaded script carries Mark-of-the-Web.
+try {
+    Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction Stop
+} catch {
+    Write-Host "  (Could not change process execution policy: $($_.Exception.Message). Continuing.)" -ForegroundColor DarkGray
+}
 Write-Host ""
-& .\setup-windows.ps1
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File (Join-Path $TargetDir "setup-windows.ps1")

--- a/install.sh
+++ b/install.sh
@@ -382,8 +382,10 @@ if [ -d "$TARGET_DIR" ]; then
         rm -rf "$PRESERVE_DIR"
         unset PRESERVE_DIR
     fi
-    echo "Wiping for a fresh install (system tools like Claude, Node, Python are kept)..."
-    rm -rf "$TARGET_DIR"
+    # NOTE: we do NOT wipe $TARGET_DIR here. The wipe happens only AFTER the
+    # new copy has downloaded and verified (see below), so a failed download
+    # on flaky conference/hotel wifi can never leave the user with no
+    # workspace -- and no stashed user data -- at all.
 fi
 
 echo "Downloading starter kit tarball..."
@@ -404,6 +406,15 @@ if curl -fsSL --retry 3 --retry-delay 2 --connect-timeout 30 --max-time 300 "$TA
         echo "[!] Expected extracted folder not found: $EXTRACTED" >&2
         echo "    The tarball may have changed shape, or tar failed silently." >&2
         exit 1
+    fi
+    # The fresh copy is downloaded and verified -- only now is it safe to
+    # remove the previous install and swap the new one in. Doing the wipe
+    # here (not before the download) means a failed download leaves the
+    # existing workspace untouched. System tools like Claude, Node, Python
+    # live outside $TARGET_DIR and are never touched.
+    if [ -d "$TARGET_DIR" ]; then
+        echo "Wiping previous install for a fresh copy (system tools are kept)..."
+        rm -rf "$TARGET_DIR"
     fi
     mv "$EXTRACTED" "$TARGET_DIR"
     echo "Extracted to $TARGET_DIR"

--- a/marketplace-plugins.md
+++ b/marketplace-plugins.md
@@ -20,6 +20,17 @@ That's it. Plugins add new skills, agents, and commands to Claude.
 
 These marketplaces are already configured in your `.claude/settings.json`:
 
+### Bundled: Elnora Starter Plugins (`elnora-starter-plugins`)
+
+**Source**: local `directory: ./plugins` — shipped inside this repo, no clone needed
+**Trust level**: Highest — bundled with the starter kit; auto-registers when you trust the folder
+
+| Plugin | What it gives you | Best for |
+|--------|-------------------|----------|
+| **vercel** ⭐ | `/vercel:deploy`, `/vercel:setup`, `/vercel:logs`, `/vercel:integration`, plus **v0** (`/vercel:v0`, AI app builder) | Deploying apps and generating UIs |
+
+⭐ = enabled by default in this starter kit (see `.claude/settings.json`).
+
 ### 1. Anthropic Official (`claude-code-plugins`)
 
 **Source**: github.com/anthropics/claude-code
@@ -177,8 +188,9 @@ A focused set of high-quality agent skills.
 
 ## What's enabled out of the box
 
-The kit ships with three plugins already turned on in `.claude/settings.json`:
+The kit ships with four plugins already turned on in `.claude/settings.json`:
 
+- **vercel** (from `elnora-starter-plugins`, bundled) — `/vercel:deploy`, `/vercel:v0`, and more
 - **commit-commands** (from `claude-code-plugins`) — `/commit`, `/commit-push-pr`
 - **context7** (from `claude-plugins-official`) — current library docs via MCP
 - **claude-md-management** (from `claude-plugins-official`) — keeps `CLAUDE.md` tidy

--- a/plugins/vercel/skills/integration/SKILL.md
+++ b/plugins/vercel/skills/integration/SKILL.md
@@ -15,7 +15,7 @@ Discover, install, and get setup guides for Vercel Marketplace integrations. Int
    ```bash
    vercel --version
    ```
-   If missing or outdated: `pnpm i -g vercel@latest`
+   If missing or outdated: `npm i -g vercel@latest`
 
 2. **Check project is linked**:
    ```bash

--- a/plugins/vercel/skills/vercel/SKILL.md
+++ b/plugins/vercel/skills/vercel/SKILL.md
@@ -57,21 +57,6 @@ Use this to route to the correct reference file:
 - **REST API endpoints** → `references/rest-api-reference.md`
 - **Complete CLI command/flag reference** → `references/cli-complete-reference.md`
 
-## Comprehensive API & CLI Reference (Vault)
-
-For the full authoritative reference (49 CLI commands, 250+ REST API endpoints, TypeScript SDK, Terraform provider, `vercel.json` config, platform limits), load the vault doc:
-
-**Path**: `09-engineering/integrations/vercel-cli-and-rest-api-reference.md`
-
-Use the knowledge-base plugin to read this when you need to:
-- Make direct REST API calls (`vercel api` or `curl`)
-- Use the `@vercel/sdk` TypeScript SDK
-- Look up exact endpoint paths, methods, and parameters
-- Check platform limits or `vercel.json` configuration options
-- Build new automation that needs specific API endpoints
-
-The reference files in this plugin cover common workflows. The vault doc is the complete source for everything Vercel exposes.
-
 ## Anti-Patterns
 
 - **Wrong link type in monorepos with multiple projects**: `vercel link` creates `project.json`, which only tracks one project. Use `vercel link --repo` instead. When things break, check `.vercel/` first.

--- a/plugins/vercel/skills/vercel/references/getting-started.md
+++ b/plugins/vercel/skills/vercel/references/getting-started.md
@@ -11,7 +11,7 @@ npm i -g vercel
 1. **Authenticate** — `vercel login` (opens browser). For CI, use `VERCEL_TOKEN` env var instead.
 2. **Check your team** — `vercel whoami` to see current team. `vercel teams switch` to change. Linking on the wrong team is a common mistake.
 3. **Link your project** — `vercel link` (single project) or `vercel link --repo` (monorepo with multiple projects or non-root directories). Creates `.vercel/`.
-4. **Pull env vars** — `vercel pull` downloads project settings and env vars to `.env.local`.
+4. **Pull env vars** — `vercel pull` downloads project settings and env vars to `.vercel/.env.development.local`. (Use `vercel env pull` to write just the env vars to `.env.local`.)
 5. **Dev or deploy** — `vercel dev` (local server) or `vercel --prod` (production deploy).
 
 ## Project Linking

--- a/plugins/vercel/skills/vercel/references/local-development.md
+++ b/plugins/vercel/skills/vercel/references/local-development.md
@@ -16,8 +16,8 @@ vercel dev --listen 127.0.0.1:5000   # custom host and port
 ## Related Commands
 
 - `vercel link` — connect to a Vercel project. Use `--repo` for multi-project monorepos.
-- `vercel pull` — download project settings and env vars to `.env.local`
-- `vercel env pull` — download only env vars (not project settings)
+- `vercel pull` — download project settings and env vars to `.vercel/.env.<environment>.local` (default `.vercel/.env.development.local`)
+- `vercel env pull` — download only env vars (not project settings) to `.env.local`
 - `vercel init` — scaffold a new project from a Vercel example
 - `vercel open` — open the Vercel dashboard for the linked project
 

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -44,25 +44,32 @@ FAILED_STEPS=()
 # Resume / checkpoint state
 # ------------------------------------------------------------
 # This script is safe to run as many times as you like - already-installed
-# tools are detected and skipped. The checkpoint file below goes one step
-# further: it remembers one-time actions that already finished so a re-run
-# does not repeat them, and it lets the script announce "resuming" so a
-# re-run never feels like starting over.
+# tools and existing logins are detected live and skipped, so a re-run never
+# reinstalls or re-does what is already in place. The checkpoint file below
+# records which one-time actions (Claude / Codex / GitHub sign-in) finished,
+# so a re-run can announce "resuming" instead of feeling like starting over.
 #
 # Why this matters: the single most common place people stop is the Claude
 # Code sign-in step. If that happens - or the script is interrupted anywhere
 # else - just run it again. It picks up right where you left off.
 #
 #   Resume (default):   bash setup-mac.sh
-#   Start over clean:   bash setup-mac.sh --fresh
+#   Start over clean:   bash setup-mac.sh --fresh   (--restart is an alias)
 #
 # ELNORA_SETUP_STATE_FILE overrides the path (used by the test suite so a
 # local re-run of the smoke test starts from a clean slate).
 SETUP_STATE_FILE="${ELNORA_SETUP_STATE_FILE:-$HOME/.claude-starter-setup-state}"
-if [ "${1:-}" = "--fresh" ] || [ "${1:-}" = "--restart" ]; then
-    rm -f "$SETUP_STATE_FILE" 2>/dev/null || true
-    echo "  (--fresh: cleared saved progress - starting from the beginning.)"
-fi
+# Accept --fresh / --restart in any argument position (matches setup-windows.ps1,
+# which scans all of $args), not just as the first positional argument.
+for _arg in "$@"; do
+    case "$_arg" in
+        --fresh|--restart)
+            rm -f "$SETUP_STATE_FILE" 2>/dev/null || true
+            echo "  (--fresh: cleared saved progress - starting from the beginning.)"
+            break
+            ;;
+    esac
+done
 # Create the state file up front (mode 600, same as the log) so is_done/
 # mark_done never have to special-case "file missing".
 ( umask 077 && : >> "$SETUP_STATE_FILE" ) 2>/dev/null || touch "$SETUP_STATE_FILE" 2>/dev/null || true
@@ -1362,7 +1369,7 @@ PY
         # bypassPermissions gate. Three states:
         #   1. Real CI (GITHUB_ACTIONS=true && CI=true) - proceed silently.
         #   2. Local opt-in (ELNORA_HANDOFF_LOCAL_BYPASS=1) - print a 5-second
-        #      warning, then proceed. For Carmen-style local handoff testing.
+        #      warning, then proceed. For local handoff testing by a maintainer.
         #   3. Anything else - refuse. Just having ELNORA_HANDOFF_MODE=headless
         #      isn't enough; that env var is too easy to flip from a shell
         #      profile or a stray script. We want bypassPermissions to require

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -38,17 +38,17 @@ $FailedSteps = New-Object System.Collections.ArrayList
 # Resume / checkpoint state
 # ------------------------------------------------------------
 # This script is safe to run as many times as you like - already-installed
-# tools are detected and skipped. The checkpoint file below goes one step
-# further: it remembers one-time actions that already finished so a re-run
-# does not repeat them, and it lets the script announce "resuming" so a
-# re-run never feels like starting over.
+# tools and existing logins are detected live and skipped, so a re-run never
+# reinstalls or re-does what is already in place. The checkpoint file below
+# records which one-time actions (Claude / Codex / GitHub sign-in) finished,
+# so a re-run can announce "resuming" instead of feeling like starting over.
 #
 # Why this matters: the single most common place people stop is the Claude
 # Code sign-in step. If that happens - or the script is interrupted anywhere
 # else - just run it again. It picks up right where you left off.
 #
 #   Resume (default):   .\setup-windows.ps1
-#   Start over clean:   .\setup-windows.ps1 --fresh
+#   Start over clean:   .\setup-windows.ps1 --fresh   (--restart is an alias)
 #
 # ELNORA_SETUP_STATE_FILE overrides the path (used by the test suite so a
 # local re-run of the smoke test starts from a clean slate).
@@ -1625,7 +1625,7 @@ if ($agentAvailable) {
         # bypassPermissions gate. Three states:
         #   1. Real CI (GITHUB_ACTIONS=true && CI=true) - proceed silently.
         #   2. Local opt-in (ELNORA_HANDOFF_LOCAL_BYPASS=1) - print a 5-second
-        #      warning, then proceed. For Carmen-style local handoff testing.
+        #      warning, then proceed. For local handoff testing by a maintainer.
         #   3. Anything else - refuse. Just having ELNORA_HANDOFF_MODE=headless
         #      isn't enough; that env var is too easy to flip from a profile
         #      or a stray script. We want bypassPermissions to require an

--- a/tests/handoff/README.md
+++ b/tests/handoff/README.md
@@ -66,6 +66,7 @@ faster loop. Paste your keys into `.env`, then:
 ```bash
 # Mac:
 ELNORA_HANDOFF_MODE=headless \
+ELNORA_HANDOFF_LOCAL_BYPASS=1 \
 ELNORA_HANDOFF_TRANSCRIPT="$PWD/handoff-transcript.jsonl" \
 ANTHROPIC_API_KEY="$(grep ^ANTHROPIC_API_KEY= .env | cut -d= -f2-)" \
 bash setup-mac.sh
@@ -76,6 +77,7 @@ tests/handoff/assert.sh "$PWD" "$PWD/handoff-transcript.jsonl"
 ```powershell
 # Windows:
 $env:ELNORA_HANDOFF_MODE = "headless"
+$env:ELNORA_HANDOFF_LOCAL_BYPASS = "1"
 $env:ELNORA_HANDOFF_TRANSCRIPT = "$PWD\handoff-transcript.jsonl"
 # Source ANTHROPIC_API_KEY from .env or paste it
 .\setup-windows.ps1
@@ -85,6 +87,11 @@ $env:ELNORA_HANDOFF_TRANSCRIPT = "$PWD\handoff-transcript.jsonl"
 > ⚠️ Running locally re-runs the full Phase 1 install path too. If you've
 > already got everything installed it's a no-op; otherwise it'll install
 > tools on your machine.
+>
+> `ELNORA_HANDOFF_LOCAL_BYPASS=1` is required outside CI: headless mode hands
+> off to the agent with `bypassPermissions`, so the setup scripts refuse to run
+> it without this explicit opt-in (they print a 5-second abort warning, then
+> proceed). Without it — and without CI markers — the script exits 2.
 
 ## How the handoff knows it's in test mode
 
@@ -93,12 +100,14 @@ The contract is two env vars:
 - `ELNORA_HANDOFF_MODE=headless` — switches `setup-mac.sh` / `setup-windows.ps1`
   from `exec claude "<prompt>"` (interactive REPL) to `claude -p "<same
   prompt>" --permission-mode bypassPermissions --output-format stream-json
-  --verbose --max-turns 50` (one-shot, captured to transcript).
+  --verbose --max-turns 80` (one-shot, captured to transcript). For the Codex
+  agent the equivalent one-shot path is `codex exec` instead of `claude -p`.
 - `ANTHROPIC_API_KEY` — required for Claude Code to skip browser OAuth.
 
-The handoff prompt is **byte-for-byte identical** between production and
-headless mode — defined once in each setup script. Divergence there is
-the bug this test is supposed to catch.
+The handoff prompt is the same string between production and headless mode —
+defined once in each setup script. Divergence there is the bug this test is
+supposed to catch. (Nothing currently diffs the two prompt strings in an
+assertion, so keep them in sync by hand when editing either path.)
 
 `INSTALL_FOR_AGENTS.md` has a "Non-interactive / test mode" section that
 tells Claude what to do when `ELNORA_HANDOFF_MODE=headless` is set: pull


### PR DESCRIPTION
## Summary
- Refresh docs across the kit (README, getting-started, INSTALL_FOR_AGENTS, RECOVERY, TOOLS, Chrome DevTools MCP setup, handoff README)
- Update install/setup scripts (`install.sh`, `install.ps1`, `setup-mac.sh`, `setup-windows.ps1`) and the marketplace plugins list
- Update Vertex examples (`generate_video_veo.py`, `generate_voiceover_tts.py`) and Vercel skills/references
- Drop the unused CodeQL Autobuild step — the matrix only scans interpreted/config languages, which CodeQL analyzes directly
- Clarify the `lint-ascii.py` quote-tracking caveat (bash escaped-apostrophe idiom)

## Test plan
- [ ] CI (CodeQL + lint-ascii) passes on the branch
- [ ] Spot-check rendered docs for broken links

🤖 Generated with [Claude Code](https://claude.com/claude-code)