### PR TITLE
docs: mandatory Read before getting-started.md Edit (round 2 finding)

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -1363,12 +1363,14 @@ heredocs, or sed — `Edit` is the auditable interface).
 If the admonition isn't found verbatim (someone may have edited it), stop
 and surface the discrepancy — do not invent a workaround.
 
-**`docs/getting-started.md`** — around line 155 references `RECOVERY.md`. Use
-`Edit` with:
+**`docs/getting-started.md`** — around line 155 references `RECOVERY.md`.
+First `Read` the file — this is required, not optional: the `Edit` tool
+refuses to touch a file it hasn't read this session, so skipping the Read
+costs you an error + retry turn. Then use `Edit` with:
 
 - `old_string`: ``If any step fails, see [`../RECOVERY.md`](../RECOVERY.md) → "GitHub auth``
   (and continue to capture whatever sentence/paragraph that line begins —
-  read the file first to see the exact surrounding text).
+  the Read you just did shows the exact surrounding text).
 - `new_string`: rewrite to drop the `RECOVERY.md` reference. Replace the
   triage pointer with: `If any step fails, ask Claude to help debug it.`
 


### PR DESCRIPTION
## Summary
Round 2 of the test/analyze/fix cycle: all 4 runs green (12 jobs), Claude tool-error count down from 9 (baseline) to 2 — one was this doc gap (Edit-before-Read on docs/getting-started.md), the other was un-prescribable agent improvisation (a no-match grep exit 1, self-recovered). This makes the pre-edit Read explicitly mandatory, matching the README step's phrasing.

## Test plan
Doc-only change; lint runs on PR. Round 3 (bootstrap + handoff claude/codex, both OSes) dispatches after merge to confirm zero doc-prescribed flagged turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)