### PR TITLE
fix: reattach Codex/Claude handoff to TTY + retarget suggestions to business cases

### DIFF
--- a/INSTALL_FOR_AGENTS.md
+++ b/INSTALL_FOR_AGENTS.md
@@ -22,8 +22,8 @@ bootstrap, the verification checklist) is identical for both agents; only the
 tool names differ.
 
 Be transparent: announce each step before you run it, show the output, and
-explain what you found. The user is likely a lab scientist who has never
-coded before — keep your language plain and your steps small.
+explain what you found. The user is likely a business or non-technical user
+who has never coded before — keep your language plain and your steps small.
 
 ### Agent tooling adapter (Claude Code ↔ Codex)
 
@@ -523,7 +523,7 @@ the same step, before any git history exists.
    **Do not ask about visibility.** Always private. If the user requests
    public, explain: "Let's keep this one private — it can hold credentials,
    vault paths, and personal notes safely. If you want a public repo later
-   for sharing a sample protocol, create a separate one for that."
+   for sharing a sample or demo, create a separate one for that."
 
 2. **Check availability on GitHub BEFORE we touch git locally.** If
    the user already has a repo with this name on their GitHub account,
@@ -1020,12 +1020,12 @@ act on silently; do not paste it into chat.
 #### 5g. Show the user what they just got
 
 Briefly, in the user's words, list two or three concrete things you
-can now do on their behalf. Tailor it to who they are — for a lab
-scientist that's usually:
+can now do on their behalf. Tailor it to who they are — for most
+business users that's usually:
 
-- "I can pull data off your lab's web portal without you copy-pasting it."
-- "I can fill out forms (vendor portals, ordering systems) for you to
-  review before submitting."
+- "I can pull data off a web portal or dashboard without you copy-pasting it."
+- "I can fill out forms (vendor portals, ordering systems, web forms) for
+  you to review before submitting."
 - "If a web app is misbehaving, I can read the console errors and
   network requests directly instead of asking you to paste them."
 
@@ -1412,8 +1412,9 @@ what's useful for day-to-day work.
 
 1. Open this folder in your editor (or `cd` here in a terminal).
 2. Start Claude Code with `claude`.
-3. Ask Claude to do work — generate protocols, write notes, plan
-   experiments.
+3. Ask Claude to do work — triage your inbox and draft replies, research
+   a target company into a spreadsheet, turn a call transcript into a
+   draft contract, or review a document.
 4. Commit and push your changes (`git add -A && git commit && git push`)
    to keep your work backed up to GitHub.
 
@@ -1476,8 +1477,14 @@ Tell the user:
   as the local folder, so the two stay in sync.
 - This is now their repo to manage from here. Commit, push, branch, rename
   it — whatever they want.
-- Next: try asking Claude to do something — write notes, plan an
-  experiment, draft a document.
+- Next: try asking Claude to do real work. A few business cases to spark
+  ideas (drawn from what these agents actually do day to day):
+  - "Read my recent inbox, decide who needs a reply, and draft each one."
+  - "Find the right decision-maker to email at [company] and draft an intro."
+  - "Turn this call transcript into a draft contract and save it as a PDF."
+  - "Research the top 10 companies in [industry/country] into a spreadsheet."
+  - "Review this policy/contract and tell me where we're most exposed."
+  - "Turn this Markdown into a polished slide deck (or Google Doc)."
 
 If anything went wrong during setup, ask Claude in this same window for help
 debugging — they can read the install log at `~/claude-starter-install.log`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,12 +26,16 @@ Claude remembers context within a conversation. When you start a new conversatio
 
 ### Talk to Claude like a colleague
 
-You don't need special syntax. Just describe what you want in plain English:
+You don't need special syntax. Just describe what you want in plain English.
+A few business cases to get you started (these are the kinds of things the
+agents do day to day):
 
-- "Read the file `report.docx` and summarize the key findings"
-- "Create a new markdown file with meeting notes from today"
-- "Search all files in this project for mentions of 'budget'"
-- "Help me write an email to the team about the Q2 timeline"
+- "Read my recent inbox, decide who needs a reply, and draft each one"
+- "Find the right decision-maker to email at [company] and draft an intro"
+- "Turn this call transcript into a draft contract and save it as a PDF"
+- "Research the top 10 companies in [industry] into a spreadsheet"
+- "Review this contract and tell me where we're most exposed"
+- "Turn this Markdown file into a polished slide deck or Google Doc"
 
 ### Use your knowledge base
 

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -1167,11 +1167,25 @@ else
     echo ""
 fi
 
+# Resolve the handoff agent's binary, display name, and first-run auth note.
+# Done before the closing banners below so they name the agent the user
+# actually chose instead of hardcoding "Claude".
+case "$ELNORA_HANDOFF_AGENT" in
+    codex)
+        AGENT_BIN="codex"; AGENT_NAME="Codex"
+        AUTH_NOTE="On first run, a browser may open so you can sign in to your ChatGPT (OpenAI) account."
+        ;;
+    *)
+        AGENT_BIN="claude"; AGENT_NAME="Claude Code"
+        AUTH_NOTE="On first run, your browser will open to log into your Claude Pro/Max account."
+        ;;
+esac
+
 echo "==========================================="
 echo "  Quick PATH note"
 echo "==========================================="
 echo ""
-echo "  The 'claude' command is at ~/.local/bin/."
+echo "  The '$AGENT_BIN' command is at ~/.local/bin/."
 echo "  - In any terminal opened AFTER this install: works automatically."
 echo "  - In a terminal opened BEFORE this install (rare):"
 echo "      export PATH=\"\$HOME/.local/bin:\$PATH\""
@@ -1179,7 +1193,7 @@ echo "    or just open a fresh terminal window."
 echo ""
 
 echo "==========================================="
-echo "  Phase 1 complete - handing off to Claude"
+echo "  Phase 1 complete - handing off to $AGENT_NAME"
 echo "==========================================="
 echo ""
 
@@ -1206,17 +1220,19 @@ fi
 # Codex maps Claude tool names to its own equivalents).
 HANDOFF_PROMPT="Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at ~/claude-starter-install.log."
 
-# Resolve the handoff agent's binary, display name, and first-run auth note.
-case "$ELNORA_HANDOFF_AGENT" in
-    codex)
-        AGENT_BIN="codex"; AGENT_NAME="Codex"
-        AUTH_NOTE="On first run, a browser may open so you can sign in to your ChatGPT (OpenAI) account."
-        ;;
-    *)
-        AGENT_BIN="claude"; AGENT_NAME="Claude Code"
-        AUTH_NOTE="On first run, your browser will open to log into your Claude Pro/Max account."
-        ;;
-esac
+# Replace this shell with the interactive agent, reattached to the real
+# terminal. The whole script runs under `exec > >(tee "$LOG_FILE")` (top of
+# file), so stdout here is a pipe to tee, not a TTY -- and when the user ran
+# `curl ... | bash`, stdin is the exhausted curl pipe. Codex's TUI refuses
+# to start on either ("Error: stdout is not a terminal"), so reattach all
+# three fds to /dev/tty when one is available. The agent's session output
+# intentionally stops landing in $LOG_FILE from this point on.
+exec_handoff_agent() {
+    if ( : </dev/tty >/dev/tty ) 2>/dev/null; then
+        exec "$AGENT_BIN" "$HANDOFF_PROMPT" </dev/tty >/dev/tty 2>&1
+    fi
+    exec "$AGENT_BIN" "$HANDOFF_PROMPT"
+}
 
 if command -v "$AGENT_BIN" >/dev/null 2>&1; then
     if [ "${ELNORA_SKIP_HANDOFF:-}" = "1" ]; then
@@ -1487,7 +1503,7 @@ PY
         echo "Already inside VS Code - starting $AGENT_NAME in this terminal."
         echo "$AUTH_NOTE"
         echo ""
-        exec "$AGENT_BIN" "$HANDOFF_PROMPT"
+        exec_handoff_agent
     fi
 
     # The VS Code sentinel handoff drives `claude` specifically (run-handoff.sh
@@ -1549,9 +1565,9 @@ PY
     echo "$AUTH_NOTE"
     echo ""
     # exec replaces this shell - the agent takes over with the initial prompt
-    # loaded. If exec fails (no TTY, broken install), the lines below print as
-    # a fallback.
-    exec "$AGENT_BIN" "$HANDOFF_PROMPT"
+    # loaded (on /dev/tty, see exec_handoff_agent). If exec fails (broken
+    # install), the lines below print as a fallback.
+    exec_handoff_agent
 fi
 
 # Fallback: handoff agent not on PATH (its install failed) - show the manual

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1442,11 +1442,24 @@ if ($env:ELNORA_SKIP_HANDOFF -eq "1" -or $env:ELNORA_HANDOFF_MODE -eq "headless"
     Write-Host ""
 }
 
+# Resolve the handoff agent's binary, display name, and first-run auth note.
+# Done before the closing banners below so they name the agent the user
+# actually chose instead of hardcoding "Claude".
+if ($HandoffAgent -eq 'codex') {
+    $agentBin  = 'codex'
+    $agentName = 'Codex'
+    $authNote  = "On first run, a browser may open so you can sign in to your ChatGPT (OpenAI) account."
+} else {
+    $agentBin  = 'claude'
+    $agentName = 'Claude Code'
+    $authNote  = "On first run, your browser will open to log into your Claude Pro/Max account."
+}
+
 Write-Host "==========================================="
 Write-Host "  Quick PATH note"
 Write-Host "==========================================="
 Write-Host ""
-Write-Host "  'claude' is at %USERPROFILE%\.local\bin\."
+Write-Host "  '$agentBin' is at %USERPROFILE%\.local\bin\."
 Write-Host "  - In any terminal opened AFTER this install: works automatically."
 Write-Host "  - In a terminal opened BEFORE this install (rare):"
 Write-Host "      `$env:Path = `"`$env:USERPROFILE\.local\bin;`$env:Path`""
@@ -1454,7 +1467,7 @@ Write-Host "    or just open a fresh PowerShell window."
 Write-Host ""
 
 Write-Host "==========================================="
-Write-Host "  Phase 1 complete - handing off to Claude"
+Write-Host "  Phase 1 complete - handing off to $agentName"
 Write-Host "==========================================="
 Write-Host ""
 
@@ -1481,17 +1494,6 @@ try { Stop-Transcript | Out-Null } catch { }
 # below uses byte-for-byte the same string as the production handoff -
 # divergence here is the bug headless mode is supposed to catch.
 $HandoffPrompt = "Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at $env:USERPROFILE\claude-starter-install.log."
-
-# Resolve the handoff agent's binary, display name, and first-run auth note.
-if ($HandoffAgent -eq 'codex') {
-    $agentBin  = 'codex'
-    $agentName = 'Codex'
-    $authNote  = "On first run, a browser may open so you can sign in to your ChatGPT (OpenAI) account."
-} else {
-    $agentBin  = 'claude'
-    $agentName = 'Claude Code'
-    $authNote  = "On first run, your browser will open to log into your Claude Pro/Max account."
-}
 
 $agentAvailable = Get-Command $agentBin -ErrorAction SilentlyContinue
 if ($agentAvailable) {


### PR DESCRIPTION
## Summary

Fixes two install-script bugs hit on macOS when choosing **Codex**, plus refreshes the end-of-setup suggestions from lab-protocol examples to business cases.

### 1. `Error: stdout is not a terminal` at the Codex handoff
The whole of `setup-mac.sh` runs under `exec > >(tee "$LOG_FILE")`, so by the time it reaches the interactive handoff its stdout is a pipe to `tee`, not a TTY — and `curl … | bash` leaves stdin an exhausted pipe. Claude Code tolerates this; Codex's TUI hard-refuses and exits immediately. Added an `exec_handoff_agent` helper that reattaches stdin/stdout/stderr to `/dev/tty` when one is available, and falls back to a plain `exec` (CI/no-TTY). Used at both interactive handoff sites.

Verified by reproducing the exact environment under a pseudo-terminal (tee-wrapped stdout + piped stdin): the exec'd child now sees a real TTY on both fds with the prompt intact, and falls through cleanly when no controlling terminal exists.

### 2. "handing off to Claude" when the user chose Codex
The closing banner and the "Quick PATH note" hardcoded `Claude`/`claude`. Moved the agent name/bin resolution above the banners in both `setup-mac.sh` and `setup-windows.ps1` so they name the agent the user actually picked. (Windows only needed the banner fix — it logs via `Start-Transcript`, which doesn't break the TTY.)

### 3. Business-case suggestions instead of lab protocols
The kit was seeded from a techbio origin, so the "next things to try" suggestions and audience framing assumed a lab scientist. Retargeted every suggestion surface to the business cases from the Workshop 1 demos (inbox triage, find-the-decision-maker, call-to-contract, company research into a spreadsheet, contract review, Markdown→deck/Doc):

- `INSTALL_FOR_AGENTS.md` step 10 — the literal end-of-setup message
- The generated repo README ("Daily use")
- `docs/getting-started.md` ("Things to try this week")
- `5g` "what you just got" list + the "likely a lab scientist" audience framing → "business or non-technical user"

## Test plan
- `bash -n setup-mac.sh` passes.
- TTY reattach verified under a Python-allocated pty (sees TTY) and without a controlling terminal (clean fallback).
- PowerShell not parser-checked locally (no pwsh installed); changes are a block move + variable interpolation, exercised by the install-smoke-test workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)