### PR TITLE
fix: hand off to the real pty device, not the /dev/tty alias

### DIFF
--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -1225,9 +1225,26 @@ HANDOFF_PROMPT="Phase 1 of the Elnora AI Agent Hackathon Starter Kit install jus
 # file), so stdout here is a pipe to tee, not a TTY -- and when the user ran
 # `curl ... | bash`, stdin is the exhausted curl pipe. Codex's TUI refuses
 # to start on either ("Error: stdout is not a terminal"), so reattach all
-# three fds to /dev/tty when one is available. The agent's session output
-# intentionally stops landing in $LOG_FILE from this point on.
+# three fds to the terminal. The agent's session output intentionally stops
+# landing in $LOG_FILE from this point on.
+#
+# Reattach to the REAL pty device (/dev/ttysNNN on macOS, /dev/pts/N on
+# Linux), NOT the /dev/tty alias: on macOS, kqueue cannot poll an fd opened
+# from /dev/tty, so Codex's TUI panics ("reader source not set" in
+# crossterm event/read.rs) on the first input event -- including the
+# terminal's own replies to its startup queries, i.e. instantly. Claude
+# (Node) tolerates /dev/tty, so it stays as the fallback for the rare case
+# where `ps` can't name the controlling terminal.
 exec_handoff_agent() {
+    local tty_name tty_dev=""
+    tty_name="$(ps -o tty= -p $$ 2>/dev/null | tr -d '[:space:]')"
+    case "$tty_name" in
+        ""|"?"|"??") ;;  # no controlling terminal
+        *) tty_dev="/dev/$tty_name" ;;
+    esac
+    if [ -n "$tty_dev" ] && [ -c "$tty_dev" ] && ( : <"$tty_dev" >"$tty_dev" ) 2>/dev/null; then
+        exec "$AGENT_BIN" "$HANDOFF_PROMPT" <"$tty_dev" >"$tty_dev" 2>&1
+    fi
     if ( : </dev/tty >/dev/tty ) 2>/dev/null; then
         exec "$AGENT_BIN" "$HANDOFF_PROMPT" </dev/tty >/dev/tty 2>&1
     fi
@@ -1565,8 +1582,8 @@ PY
     echo "$AUTH_NOTE"
     echo ""
     # exec replaces this shell - the agent takes over with the initial prompt
-    # loaded (on /dev/tty, see exec_handoff_agent). If exec fails (broken
-    # install), the lines below print as a fallback.
+    # loaded (on the controlling tty, see exec_handoff_agent). If exec fails
+    # (broken install), the lines below print as a fallback.
     exec_handoff_agent
 fi
 


### PR DESCRIPTION
## Problem

The end-of-install handoff to **Codex always crashed** with:

```
The application panicked (crashed).
Message:  reader source not set
Location: .../crossterm-.../src/event/read.rs:39
```

followed by terminal-query garbage (`6;1R`, `rgb:...`, `1;2c`) spilling into zsh. Reproduced in both VS Code's integrated terminal and Terminal.app.

## Root cause

`exec_handoff_agent` reattached the agent with `</dev/tty >/dev/tty`. On macOS, **kqueue cannot poll an fd opened from the `/dev/tty` alias device** — Codex's event reader (crossterm fork) fails to initialize and panics on the first input event. A real terminal answers Codex's startup queries (cursor position, OSC 10/11 colors, DA) within milliseconds, so the panic is instant. Claude Code (Node) tolerates `/dev/tty`, which is why only the Codex handoff broke.

Verified empirically under `expect(1)` on the affected machine (codex-cli 0.139.0):
- `exec codex "prompt" </dev/tty >/dev/tty 2>&1` → panic (also with `<>/dev/tty` read-write)
- inherited pty fd → works
- `exec codex "prompt" </dev/ttysNNN >/dev/ttysNNN 2>&1` → works

## Fix

Resolve the controlling terminal's real device (`/dev/ttysNNN` on macOS, `/dev/pts/N` on Linux) via `ps -o tty= -p $$` and reattach the agent to that. `/dev/tty` and bare `exec` remain as fallbacks for the rare no-controlling-terminal case.

## Verification

Simulated the installer's exact fd setup (stdout → `tee` pipe, stdin ← `/dev/tty`) under `expect` with a pty: old code panics instantly; with this fix the Codex TUI launches and stays alive through real keyboard input. `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)