### PR TITLE
feat: launch the chosen agent from the VS Code handoff + agent language choice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,11 +68,13 @@ azure-*.json
 # step 6c.4's `git add .`). Step 0.6 deletes it locally once consumed.
 .elnora-handoff-resume.json
 
-# One-shot Phase 1 -> Phase 2 handoff sentinel. setup-mac.sh / setup-windows.ps1
-# write the literal handoff prompt into this file, then open VS Code; the
-# .vscode/run-handoff.{sh,ps1} helper reads it once and deletes it. Pure
+# One-shot Phase 1 -> Phase 2 handoff sentinels. setup-mac.sh / setup-windows.ps1
+# write the literal handoff prompt into .handoff-pending and the chosen agent
+# (claude|codex) into .handoff-agent, then open VS Code; the
+# .vscode/run-handoff.{sh,ps1} helper reads both once and deletes them. Pure
 # runtime state — never committed.
 .vscode/.handoff-pending
+.vscode/.handoff-agent
 
 # Runtime scratch folder — regenerable state, logs, downloaded artifacts
 # Keep the folder (README + .gitkeep) but ignore everything else inside

--- a/.vscode/run-handoff.ps1
+++ b/.vscode/run-handoff.ps1
@@ -3,8 +3,10 @@
 # ============================================================
 # Fired by .vscode/tasks.json on folderOpen. Consumes the one-shot sentinel
 # .vscode\.handoff-pending (whose contents ARE the handoff prompt -- single
-# source of truth lives in setup-windows.ps1). On subsequent opens (sentinel
-# absent), exits silently so the task is a no-op.
+# source of truth lives in setup-windows.ps1) plus its sibling
+# .vscode\.handoff-agent (which names the agent to launch: claude or codex).
+# On subsequent opens (sentinel absent), exits silently so the task is a
+# no-op.
 #
 # Stay pure ASCII. Windows PowerShell 5.1 (the default `powershell.exe` the
 # VS Code task invokes) reads BOM-less .ps1 files as ANSI/CP-1252; UTF-8
@@ -12,8 +14,9 @@
 
 $ErrorActionPreference = "Stop"
 
-$RepoDir  = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
-$Sentinel = Join-Path $RepoDir ".vscode\.handoff-pending"
+$RepoDir   = Split-Path -Parent (Split-Path -Parent $MyInvocation.MyCommand.Path)
+$Sentinel  = Join-Path $RepoDir ".vscode\.handoff-pending"
+$AgentFile = Join-Path $RepoDir ".vscode\.handoff-agent"
 
 # No sentinel = nothing to do. This is the steady state on every folder
 # open after the initial handoff. Exit 0 so VS Code's task UI doesn't show
@@ -25,27 +28,39 @@ if (-not (Test-Path -LiteralPath $Sentinel)) {
 $Prompt = Get-Content -LiteralPath $Sentinel -Raw
 
 # Trim trailing newline. PowerShell's Set-Content / WriteAllText combos
-# usually emit a trailing CRLF; claude's CLI doesn't care, but it makes
+# usually emit a trailing CRLF; the agent CLIs don't care, but it makes
 # transcripts and any echoes cleaner.
 $Prompt = $Prompt.TrimEnd("`r", "`n")
 
-# Delete the sentinel BEFORE launching claude. If we delete after, a crash
-# or Ctrl+C in claude leaves the sentinel and would re-fire next folder-open
-# with the same stale prompt. Pre-deleting also makes the handoff exactly
-# one-shot regardless of whether claude exits cleanly.
+# Which agent drives Phase 2. Allowlisted because this value is invoked as a
+# command: anything other than the two agents the kit installs collapses to
+# the claude default (also covers pre-agent-file installs, where the file
+# simply doesn't exist).
+$AgentBin = "claude"
+if (Test-Path -LiteralPath $AgentFile) {
+    $agentRaw = (Get-Content -LiteralPath $AgentFile -Raw).Trim()
+    if ($agentRaw -eq "codex") { $AgentBin = "codex" }
+}
+$AgentName = if ($AgentBin -eq "codex") { "Codex" } else { "Claude" }
+
+# Delete the sentinel BEFORE launching the agent. If we delete after, a crash
+# or Ctrl+C in the agent leaves the sentinel and would re-fire next
+# folder-open with the same stale prompt. Pre-deleting also makes the handoff
+# exactly one-shot regardless of whether the agent exits cleanly.
 Remove-Item -LiteralPath $Sentinel -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $AgentFile -Force -ErrorAction SilentlyContinue
 
 # Belt-and-suspenders PATH fix. VS Code caches PATH at app launch time, so
-# if VS Code was already running when setup-windows.ps1 installed Claude
-# Code into %USERPROFILE%\.local\bin, the integrated terminal won't see
-# `claude` on PATH. We prepend the canonical install dir here.
-$claudeBin = Join-Path $env:USERPROFILE ".local\bin"
-if ((Test-Path $claudeBin) -and (($env:Path -split ';') -notcontains $claudeBin)) {
-    $env:Path = "$claudeBin;$env:Path"
+# if VS Code was already running when setup-windows.ps1 installed the agent
+# into %USERPROFILE%\.local\bin, the integrated terminal won't see it on
+# PATH. We prepend the canonical install dir here.
+$agentBinDir = Join-Path $env:USERPROFILE ".local\bin"
+if ((Test-Path $agentBinDir) -and (($env:Path -split ';') -notcontains $agentBinDir)) {
+    $env:Path = "$agentBinDir;$env:Path"
 }
 
-if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
-    Write-Host "[!] 'claude' command not found on PATH inside VS Code's terminal." -ForegroundColor Red
+if (-not (Get-Command $AgentBin -ErrorAction SilentlyContinue)) {
+    Write-Host "[!] '$AgentBin' command not found on PATH inside VS Code's terminal." -ForegroundColor Red
     Write-Host "    Quit VS Code fully (File -> Exit) and reopen -- the integrated" -ForegroundColor Red
     Write-Host "    terminal caches PATH at app launch. If that doesn't help," -ForegroundColor Red
     Write-Host "    re-run setup: .\setup-windows.ps1" -ForegroundColor Red
@@ -55,12 +70,12 @@ if (-not (Get-Command claude -ErrorAction SilentlyContinue)) {
 Set-Location -LiteralPath $RepoDir
 
 Write-Host "===========================================" -ForegroundColor Cyan
-Write-Host "  Continuing Elnora setup with Claude" -ForegroundColor Cyan
+Write-Host "  Continuing Elnora setup with $AgentName" -ForegroundColor Cyan
 Write-Host "===========================================" -ForegroundColor Cyan
 Write-Host ""
 
-# PowerShell has no `exec`. Call claude as a child process and let it own
+# PowerShell has no `exec`. Call the agent as a child process and let it own
 # the terminal until it exits, then exit with its return code so the task
 # panel reports correctly.
-& claude $Prompt
+& $AgentBin $Prompt
 exit $LASTEXITCODE

--- a/.vscode/run-handoff.ps1
+++ b/.vscode/run-handoff.ps1
@@ -63,7 +63,7 @@ if (-not (Get-Command $AgentBin -ErrorAction SilentlyContinue)) {
     Write-Host "[!] '$AgentBin' command not found on PATH inside VS Code's terminal." -ForegroundColor Red
     Write-Host "    Quit VS Code fully (File -> Exit) and reopen -- the integrated" -ForegroundColor Red
     Write-Host "    terminal caches PATH at app launch. If that doesn't help," -ForegroundColor Red
-    Write-Host "    re-run setup: .\setup-windows.ps1" -ForegroundColor Red
+    Write-Host "    re-run setup: powershell -ExecutionPolicy Bypass -File `"$RepoDir\setup-windows.ps1`"" -ForegroundColor Red
     exit 127
 }
 

--- a/.vscode/run-handoff.sh
+++ b/.vscode/run-handoff.sh
@@ -4,13 +4,16 @@
 # ============================================================
 # Fired by .vscode/tasks.json on folderOpen. Consumes the one-shot sentinel
 # `.vscode/.handoff-pending` (whose contents ARE the handoff prompt -- single
-# source of truth lives in setup-mac.sh). On subsequent opens (sentinel
-# absent), exits silently so the task is a no-op.
+# source of truth lives in setup-mac.sh) plus its sibling
+# `.vscode/.handoff-agent` (which names the agent to launch: claude or
+# codex). On subsequent opens (sentinel absent), exits silently so the task
+# is a no-op.
 
 set -eu
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SENTINEL="$REPO_DIR/.vscode/.handoff-pending"
+AGENT_FILE="$REPO_DIR/.vscode/.handoff-agent"
 
 # No sentinel = nothing to do. This is the steady state on every folder
 # open after the initial handoff. Exit 0 so VS Code's task UI doesn't show
@@ -21,22 +24,37 @@ fi
 
 PROMPT="$(cat "$SENTINEL")"
 
-# Delete the sentinel BEFORE launching claude. If we delete after, a crash
-# or Ctrl+C in claude leaves the sentinel and would re-fire next folder-open
-# with the same stale prompt. Pre-deleting also makes the handoff exactly
-# one-shot regardless of whether claude exits cleanly.
-rm -f "$SENTINEL"
+# Which agent drives Phase 2. Allowlisted because this value is exec'd as a
+# command: anything other than the two agents the kit installs collapses to
+# the claude default (also covers pre-agent-file installs, where the file
+# simply doesn't exist).
+AGENT_BIN="claude"
+if [ -f "$AGENT_FILE" ]; then
+    case "$(tr -d '[:space:]' < "$AGENT_FILE")" in
+        codex) AGENT_BIN="codex" ;;
+    esac
+fi
+case "$AGENT_BIN" in
+    codex) AGENT_NAME="Codex" ;;
+    *)     AGENT_NAME="Claude" ;;
+esac
+
+# Delete the sentinel BEFORE launching the agent. If we delete after, a crash
+# or Ctrl+C in the agent leaves the sentinel and would re-fire next
+# folder-open with the same stale prompt. Pre-deleting also makes the handoff
+# exactly one-shot regardless of whether the agent exits cleanly.
+rm -f "$SENTINEL" "$AGENT_FILE"
 
 # Belt-and-suspenders PATH fix. VS Code caches PATH at app launch time, so
-# if VS Code was already running when setup-mac.sh installed Claude Code
-# into ~/.local/bin, the integrated terminal won't see `claude` on PATH.
+# if VS Code was already running when setup-mac.sh installed the agent
+# into ~/.local/bin, the integrated terminal won't see it on PATH.
 # We prepend the canonical install dirs here. Harmless if already present
-# (PATH dedup is the user's shell's problem, not ours -- claude only needs
+# (PATH dedup is the user's shell's problem, not ours -- the agent only needs
 # to resolve once).
 export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
 
-if ! command -v claude >/dev/null 2>&1; then
-    echo "[!] 'claude' command not found on PATH inside VS Code's terminal." >&2
+if ! command -v "$AGENT_BIN" >/dev/null 2>&1; then
+    echo "[!] '$AGENT_BIN' command not found on PATH inside VS Code's terminal." >&2
     echo "    Quit VS Code fully (Cmd+Q) and reopen -- the integrated" >&2
     echo "    terminal caches PATH at app launch. If that doesn't help," >&2
     echo "    re-run setup: ./setup-mac.sh" >&2
@@ -46,10 +64,10 @@ fi
 cd "$REPO_DIR"
 
 echo "==========================================="
-echo "  Continuing Elnora setup with Claude"
+echo "  Continuing Elnora setup with $AGENT_NAME"
 echo "==========================================="
 echo ""
 
-# exec replaces this shell with claude -- once Phase 2 wraps up, the user's
-# integrated terminal lands at a normal shell prompt inside the repo.
-exec claude "$PROMPT"
+# exec replaces this shell with the agent -- once Phase 2 wraps up, the
+# user's integrated terminal lands at a normal shell prompt inside the repo.
+exec "$AGENT_BIN" "$PROMPT"

--- a/.vscode/run-handoff.sh
+++ b/.vscode/run-handoff.sh
@@ -57,7 +57,7 @@ if ! command -v "$AGENT_BIN" >/dev/null 2>&1; then
     echo "[!] '$AGENT_BIN' command not found on PATH inside VS Code's terminal." >&2
     echo "    Quit VS Code fully (Cmd+Q) and reopen -- the integrated" >&2
     echo "    terminal caches PATH at app launch. If that doesn't help," >&2
-    echo "    re-run setup: ./setup-mac.sh" >&2
+    echo "    re-run setup: bash \"$REPO_DIR/setup-mac.sh\"" >&2
     exit 127
 fi
 

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,14 +1,15 @@
 // Auto-fires once on first folder open after `setup-mac.sh` /
 // `setup-windows.ps1` finishes Phase 1. The setup script writes the sentinel
-// `.vscode/.handoff-pending` containing the handoff prompt, then opens VS
-// Code at this folder. The helper script consumes the sentinel and exec's
-// `claude` inside VS Code's integrated terminal. On subsequent folder-opens
-// (sentinel absent) the helper exits silently.
+// `.vscode/.handoff-pending` containing the handoff prompt (plus
+// `.vscode/.handoff-agent` naming the chosen agent), then opens VS Code at
+// this folder. The helper script consumes both and exec's the agent
+// (`claude` or `codex`) inside VS Code's integrated terminal. On subsequent
+// folder-opens (sentinel absent) the helper exits silently.
 {
   "version": "2.0.0",
   "tasks": [
     {
-      "label": "Continue Elnora setup with Claude",
+      "label": "Continue Elnora setup with your coding agent",
       "type": "shell",
       "command": "bash",
       "args": ["${workspaceFolder}/.vscode/run-handoff.sh"],

--- a/RECOVERY.md
+++ b/RECOVERY.md
@@ -135,13 +135,13 @@ push didn't land on `origin/main`.
 
 ---
 
-## 6. "VS Code opened but Claude never started" (auto-task prompt missed)
+## 6. "VS Code opened but my agent never started" (auto-task prompt missed)
 
-**Symptom:** Phase 1 said `Opening VS Code - Claude will continue Phase 2
-setup there`, your bootstrap terminal exited cleanly, VS Code came up at
-the starter-kit folder, but no terminal panel ever opened with Claude
-running. You may have seen a yellow popup at the bottom-right and dismissed
-it without reading.
+**Symptom:** Phase 1 said `Opening VS Code - Claude Code will continue
+Phase 2 setup there` (or `... Codex will continue ...`), your bootstrap
+terminal exited cleanly, VS Code came up at the starter-kit folder, but no
+terminal panel ever opened with the agent running. You may have seen a
+yellow popup at the bottom-right and dismissed it without reading.
 
 **What happened:** VS Code has *two* one-time security prompts on first
 open of a workspace with auto-running tasks:
@@ -168,7 +168,8 @@ it, the handoff task is configured but inert.
   powershell -ExecutionPolicy Bypass -File .vscode\run-handoff.ps1   # Windows
   ```
   This is the same script the auto-task fires; it consumes the same
-  one-shot sentinel and starts Claude on the Phase 2 prompt.
+  one-shot sentinel and starts your chosen agent (Claude or Codex) on the
+  Phase 2 prompt.
 
 - **Re-arm the auto-task for next time.** Open VS Code's command palette
   (`Cmd+Shift+P` / `Ctrl+Shift+P`) and run **`Tasks: Manage Automatic Tasks`**.
@@ -176,14 +177,15 @@ it, the handoff task is configured but inert.
   future trusted workspace (including future starter-kit installs) will
   auto-fire without prompting.
 
-- **Just open Claude in the terminal yourself.** If you'd rather skip the
-  task system entirely, run:
+- **Just open the agent in the terminal yourself.** If you'd rather skip
+  the task system entirely, run (swap `claude` for `codex` if Codex is your
+  agent):
   ```
   claude "Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup."
   ```
   This is byte-identical to what the helper does.
 
-Any of the three gets you to the same place: Claude reading
+Any of the three gets you to the same place: your agent reading
 `INSTALL_FOR_AGENTS.md` and finishing Phase 2.
 
 ---

--- a/setup-mac.sh
+++ b/setup-mac.sh
@@ -1213,12 +1213,109 @@ if [ -n "${GITHUB_PATH:-}" ]; then
     echo "  (CI: propagated PATH to \$GITHUB_PATH for downstream steps)"
 fi
 
+# --- Agent language choice --------------------------------------------------
+# Let the user pick the language their agent speaks, before the agent ever
+# starts. Claude Code reads the `language` key in .claude/settings.json (the
+# exact key /config > Language writes), so setting it here means even the
+# agent's FIRST handoff message is already in the chosen language. Codex has
+# no config equivalent, so it gets a marker-bounded Language section in
+# AGENTS.md (which it auto-reads at session start). Both also get a sentence
+# appended to the handoff prompt as belt-and-suspenders.
+#
+# English (the default, and what Enter picks) changes nothing: no file
+# writes, no prompt suffix - so the headless/CI handoff prompt stays
+# byte-for-byte identical to the default interactive one. The prompt is
+# skipped entirely in CI (ELNORA_SKIP_HANDOFF / headless mode / no TTY).
+AGENT_LANG="English"
+LANG_PROMPT_SUFFIX=""
+if [ "${ELNORA_SKIP_HANDOFF:-}" != "1" ] && [ "${ELNORA_HANDOFF_MODE:-}" != "headless" ] && [ -t 0 ]; then
+    echo "  $AGENT_NAME can speak with you in any language."
+    read -r -p "  Which language should it use? [English] " _lang_input || _lang_input=""
+    _lang_input="$(printf '%s' "$_lang_input" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    if [ -n "$_lang_input" ]; then
+        AGENT_LANG="$_lang_input"
+    fi
+    echo ""
+fi
+
+# Idempotent AGENTS.md helper: strip any previous language block (marker-
+# bounded, from an earlier run) plus trailing blank lines, so re-runs never
+# duplicate the block or accumulate separator lines.
+strip_agents_md_language_block() {
+    [ -f "AGENTS.md" ] || return 0
+    if awk '
+        /<!-- elnora:language:start -->/ { skip = 1; next }
+        /<!-- elnora:language:end -->/   { skip = 0; next }
+        skip { next }
+        { lines[++n] = $0 }
+        END {
+            while (n > 0 && lines[n] ~ /^[[:space:]]*$/) n--
+            for (i = 1; i <= n; i++) print lines[i]
+        }
+    ' AGENTS.md > AGENTS.md.tmp 2>/dev/null; then
+        mv AGENTS.md.tmp AGENTS.md
+    else
+        rm -f AGENTS.md.tmp
+    fi
+}
+
+if [ "$AGENT_LANG" != "English" ]; then
+    # Claude Code: parse-edit .claude/settings.json with node (installed in
+    # Phase 1) - never sed JSON. On any failure the file is left alone and
+    # the handoff-prompt sentence below still carries the instruction.
+    if [ -f ".claude/settings.json" ] && command -v node >/dev/null 2>&1; then
+        if node -e '
+const fs = require("fs");
+const [p, lang] = process.argv.slice(1);
+const j = JSON.parse(fs.readFileSync(p, "utf8"));
+j.language = lang;
+fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+' ".claude/settings.json" "$AGENT_LANG" 2>/dev/null; then
+            echo "  Claude Code language set to: $AGENT_LANG (change anytime with /config)"
+        else
+            echo "  [WARN] Could not update .claude/settings.json - the agent will be told your language via the handoff prompt instead." >&2
+        fi
+    fi
+
+    # Codex (and any AGENTS.md-reading agent): rewrite the language block.
+    if [ -f "AGENTS.md" ]; then
+        strip_agents_md_language_block
+        cat >> AGENTS.md <<EOF
+
+<!-- elnora:language:start -->
+## Language
+
+Always speak with the user in $AGENT_LANG. Keep code, shell commands, file
+contents, commit messages, and technical identifiers in English.
+<!-- elnora:language:end -->
+EOF
+        echo "  AGENTS.md language note set to: $AGENT_LANG"
+    fi
+
+    LANG_PROMPT_SUFFIX=" The user chose to interact in $AGENT_LANG - speak with them in $AGENT_LANG from your first message onward (keep code, commands, and file contents in English)."
+elif grep -q '<!-- elnora:language:start -->' AGENTS.md 2>/dev/null; then
+    # Re-run reverting to English: undo the earlier non-English choice so the
+    # agent doesn't keep speaking the old language.
+    strip_agents_md_language_block
+    if [ -f ".claude/settings.json" ] && command -v node >/dev/null 2>&1; then
+        node -e '
+const fs = require("fs");
+const p = process.argv[1];
+const j = JSON.parse(fs.readFileSync(p, "utf8"));
+delete j.language;
+fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+' ".claude/settings.json" 2>/dev/null || true
+    fi
+    echo "  Agent language reset to English."
+fi
+
 # The exact prompt handed to the agent. Defined once so the headless test mode
 # below uses byte-for-byte the same string as the production handoff -
 # divergence here is the bug headless mode is supposed to catch. Both agents
 # read INSTALL_FOR_AGENTS.md (it carries an "Agent tooling adapter" section so
-# Codex maps Claude tool names to its own equivalents).
-HANDOFF_PROMPT="Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at ~/claude-starter-install.log."
+# Codex maps Claude tool names to its own equivalents). LANG_PROMPT_SUFFIX is
+# empty unless the user picked a non-English language above (never in CI).
+HANDOFF_PROMPT="Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at ~/claude-starter-install.log.${LANG_PROMPT_SUFFIX}"
 
 # Replace this shell with the interactive agent, reattached to the real
 # terminal. The whole script runs under `exec > >(tee "$LOG_FILE")` (top of
@@ -1497,20 +1594,21 @@ PY
     # Interactive handoff. Three branches by environment:
     #
     #   1. Already inside VS Code's integrated terminal ($TERM_PROGRAM=vscode):
-    #      the user has the IDE on screen already, so just exec claude in
+    #      the user has the IDE on screen already, so just exec the agent in
     #      this shell. No window-launching dance needed.
     #
     #   2. `code` CLI on PATH and the user hasn't opted out: write a one-shot
-    #      sentinel containing the handoff prompt, open VS Code at this repo,
-    #      and exit. VS Code's runOn:folderOpen task picks up the sentinel and
-    #      hands off to claude inside the integrated terminal -- so users get
-    #      the file tree, source control panel, and IDE around their session
-    #      instead of a bare Terminal.app. ELNORA_SKIP_VSCODE_HANDOFF=1 is
-    #      the user-facing escape hatch.
+    #      sentinel containing the handoff prompt (plus a sibling file naming
+    #      the chosen agent), open VS Code at this repo, and exit. VS Code's
+    #      runOn:folderOpen task picks up the sentinel and hands off to the
+    #      agent (claude or codex) inside the integrated terminal -- so users
+    #      get the file tree, source control panel, and IDE around their
+    #      session instead of a bare Terminal.app.
+    #      ELNORA_SKIP_VSCODE_HANDOFF=1 is the user-facing escape hatch.
     #
-    #   3. Fallback: claude in this shell (today's behavior). Triggered when
-    #      VS Code wasn't installed (ELNORA_SKIP_OPTIONAL_INSTALLS=1) or the
-    #      `code` shim couldn't be created (brew bin not writable, Cursor
+    #   3. Fallback: the agent in this shell (today's behavior). Triggered
+    #      when VS Code wasn't installed (ELNORA_SKIP_OPTIONAL_INSTALLS=1) or
+    #      the `code` shim couldn't be created (brew bin not writable, Cursor
     #      instead of VS Code, etc.).
     if [ "${TERM_PROGRAM:-}" = "vscode" ]; then
         # Already in VS Code, so we don't launch a window -- but still drop the
@@ -1523,19 +1621,19 @@ PY
         exec_handoff_agent
     fi
 
-    # The VS Code sentinel handoff drives `claude` specifically (run-handoff.sh
-    # exec's claude), so it only applies when Claude is the handoff agent. Codex
-    # falls through to the terminal exec below (still inside VS Code's integrated
-    # terminal when launched from there).
-    if [ "$AGENT_BIN" = "claude" ] && command -v code >/dev/null 2>&1 && [ "${ELNORA_SKIP_VSCODE_HANDOFF:-}" != "1" ]; then
+    if command -v code >/dev/null 2>&1 && [ "${ELNORA_SKIP_VSCODE_HANDOFF:-}" != "1" ]; then
         VSCODE_DIR="$SCRIPT_DIR/.vscode"
         SENTINEL="$VSCODE_DIR/.handoff-pending"
+        AGENT_SENTINEL="$VSCODE_DIR/.handoff-agent"
         if [ -d "$VSCODE_DIR" ] && [ -f "$VSCODE_DIR/run-handoff.sh" ]; then
             # The sentinel's content IS the prompt -- keeps a single source of
-            # truth ($HANDOFF_PROMPT in this script). The helper reads, deletes,
-            # then exec's claude. Pre-delete on the helper side guarantees the
-            # task is one-shot even if claude crashes.
+            # truth ($HANDOFF_PROMPT in this script). The sibling agent file
+            # names the agent the helper should launch (claude or codex). The
+            # helper reads both, deletes both, then exec's the agent.
+            # Pre-delete on the helper side guarantees the task is one-shot
+            # even if the agent crashes.
             printf '%s' "$HANDOFF_PROMPT" > "$SENTINEL"
+            printf '%s' "$AGENT_BIN" > "$AGENT_SENTINEL"
             chmod +x "$VSCODE_DIR/run-handoff.sh" 2>/dev/null || true
 
             # Create the named workspace file + set restoreWindows BEFORE we
@@ -1543,7 +1641,7 @@ PY
             # window sticks across relaunches.
             ensure_vscode_workspace || true
 
-            echo "Opening VS Code - Claude will continue Phase 2 setup there."
+            echo "Opening VS Code - $AGENT_NAME will continue Phase 2 setup there."
             echo ""
             echo "VS Code will show TWO one-time prompts before the handoff fires."
             echo "Click through both:"
@@ -1553,11 +1651,10 @@ PY
             echo "      automatically. Do you want to allow automatic tasks ...?'"
             echo "       -> Click 'Allow'  (VS Code remembers this globally)"
             echo ""
-            echo "Once both are approved, an integrated terminal opens with Claude"
-            echo "already on the Phase 2 prompt. On first run, your browser will"
-            echo "open to log into your Claude Pro/Max account."
+            echo "Once both are approved, an integrated terminal opens with $AGENT_NAME"
+            echo "already on the Phase 2 prompt. $AUTH_NOTE"
             echo ""
-            echo "If you click Disallow on the second prompt, or Claude does not"
+            echo "If you click Disallow on the second prompt, or $AGENT_NAME does not"
             echo "auto-start for any other reason, open a terminal in VS Code"
             echo "(Ctrl+\` or View > Terminal) and run:"
             echo "    bash .vscode/run-handoff.sh"
@@ -1574,7 +1671,7 @@ PY
                 exit 0
             fi
             echo "  [!] 'code' command failed - falling back to terminal handoff." >&2
-            rm -f "$SENTINEL"
+            rm -f "$SENTINEL" "$AGENT_SENTINEL"
         fi
     fi
 

--- a/setup-windows.ps1
+++ b/setup-windows.ps1
@@ -1486,6 +1486,92 @@ if ($env:GITHUB_PATH) {
     Write-Host "  (CI: propagated PATH to `$GITHUB_PATH for downstream steps)"
 }
 
+# --- Agent language choice ---------------------------------------------------
+# Let the user pick the language their agent speaks, before the agent ever
+# starts. Claude Code reads the `language` key in .claude/settings.json (the
+# exact key /config > Language writes), so setting it here means even the
+# agent's FIRST handoff message is already in the chosen language. Codex has
+# no config equivalent, so it gets a marker-bounded Language section in
+# AGENTS.md (which it auto-reads at session start). Both also get a sentence
+# appended to the handoff prompt as belt-and-suspenders.
+#
+# English (the default, and what Enter picks) changes nothing: no file
+# writes, no prompt suffix - so the headless/CI handoff prompt stays
+# byte-for-byte identical to the default interactive one. The prompt is
+# skipped entirely in CI (ELNORA_SKIP_HANDOFF / headless mode / no console).
+
+# Parse-edit .claude/settings.json with node (installed in Phase 1) - never
+# regex JSON. The script goes through a temp file because PowerShell 5.1
+# mangles embedded double quotes in arguments to native commands (node -e).
+# "__RESET__" removes the key (revert-to-English on a re-run).
+function Set-ClaudeLanguage([string]$lang) {
+    if (-not (Test-Path ".claude/settings.json")) { return $false }
+    if (-not (Get-Command node -ErrorAction SilentlyContinue)) { return $false }
+    $js = @'
+const fs = require("fs");
+const [p, lang] = process.argv.slice(2);
+const j = JSON.parse(fs.readFileSync(p, "utf8"));
+if (lang === "__RESET__") { delete j.language; } else { j.language = lang; }
+fs.writeFileSync(p, JSON.stringify(j, null, 2) + "\n");
+'@
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) "elnora-set-language.js"
+    try {
+        Set-Content -Path $tmp -Value $js -Encoding ASCII
+        & node $tmp ".claude/settings.json" $lang 2>$null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    } finally {
+        Remove-Item $tmp -ErrorAction SilentlyContinue
+    }
+}
+
+# Idempotent AGENTS.md helper: strip any previous language block (marker-
+# bounded, from an earlier run) plus trailing blank lines, so re-runs never
+# duplicate the block or accumulate separator lines. Returns the stripped
+# content WITHOUT writing it back (callers decide what to append).
+function Get-AgentsMdWithoutLanguageBlock {
+    $raw = Get-Content "AGENTS.md" -Raw
+    $stripped = [regex]::Replace($raw, "(?s)\r?\n?<!-- elnora:language:start -->.*?<!-- elnora:language:end -->\r?\n?", "")
+    return $stripped.TrimEnd()
+}
+
+$AgentLang = "English"
+$LangPromptSuffix = ""
+$canPromptLang = ($env:ELNORA_SKIP_HANDOFF -ne "1") -and
+                 ($env:ELNORA_HANDOFF_MODE -ne "headless") -and
+                 (-not [Console]::IsInputRedirected)
+if ($canPromptLang) {
+    Write-Host "  $agentName can speak with you in any language."
+    $langInput = Read-Host "  Which language should it use? [English]"
+    if (-not [string]::IsNullOrWhiteSpace($langInput)) { $AgentLang = $langInput.Trim() }
+    Write-Host ""
+}
+
+if ($AgentLang -ne "English") {
+    if (Set-ClaudeLanguage $AgentLang) {
+        Write-Host "  Claude Code language set to: $AgentLang (change anytime with /config)"
+    } else {
+        Write-Host "  [WARN] Could not update .claude/settings.json - the agent will be told your language via the handoff prompt instead." -ForegroundColor Yellow
+    }
+    if (Test-Path "AGENTS.md") {
+        $agentsMdPath = Join-Path (Get-Location) "AGENTS.md"
+        $langBlock = "<!-- elnora:language:start -->`n## Language`n`nAlways speak with the user in $AgentLang. Keep code, shell commands, file`ncontents, commit messages, and technical identifiers in English.`n<!-- elnora:language:end -->"
+        $newContent = (Get-AgentsMdWithoutLanguageBlock) + "`n`n" + $langBlock + "`n"
+        [System.IO.File]::WriteAllText($agentsMdPath, $newContent, [System.Text.UTF8Encoding]::new($false))
+        Write-Host "  AGENTS.md language note set to: $AgentLang"
+    }
+    $LangPromptSuffix = " The user chose to interact in $AgentLang - speak with them in $AgentLang from your first message onward (keep code, commands, and file contents in English)."
+} elseif ((Test-Path "AGENTS.md") -and ((Get-Content "AGENTS.md" -Raw) -match 'elnora:language:start')) {
+    # Re-run reverting to English: undo the earlier non-English choice so the
+    # agent doesn't keep speaking the old language.
+    $agentsMdPath = Join-Path (Get-Location) "AGENTS.md"
+    $newContent = (Get-AgentsMdWithoutLanguageBlock) + "`n"
+    [System.IO.File]::WriteAllText($agentsMdPath, $newContent, [System.Text.UTF8Encoding]::new($false))
+    [void](Set-ClaudeLanguage "__RESET__")
+    Write-Host "  Agent language reset to English."
+}
+
 # Close the transcript before handing off, so the log file is flushed and
 # Claude can read it as part of Phase 2.
 try { Stop-Transcript | Out-Null } catch { }
@@ -1493,7 +1579,9 @@ try { Stop-Transcript | Out-Null } catch { }
 # The exact prompt handed to Claude. Defined once so the headless test mode
 # below uses byte-for-byte the same string as the production handoff -
 # divergence here is the bug headless mode is supposed to catch.
-$HandoffPrompt = "Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at $env:USERPROFILE\claude-starter-install.log."
+# $LangPromptSuffix is empty unless the user picked a non-English language
+# above (never in CI).
+$HandoffPrompt = "Phase 1 of the Elnora AI Agent Hackathon Starter Kit install just completed. Please read INSTALL_FOR_AGENTS.md in this directory and finish Phase 2 setup. The Phase 1 install log is at $env:USERPROFILE\claude-starter-install.log.$($LangPromptSuffix)"
 
 $agentAvailable = Get-Command $agentBin -ErrorAction SilentlyContinue
 if ($agentAvailable) {
@@ -1724,20 +1812,21 @@ if ($agentAvailable) {
     # Interactive handoff. Three branches by environment:
     #
     #   1. Already inside VS Code's integrated terminal ($env:TERM_PROGRAM=vscode):
-    #      the user has the IDE on screen already, so just call claude in this
-    #      shell. No window-launching dance needed.
+    #      the user has the IDE on screen already, so just call the agent in
+    #      this shell. No window-launching dance needed.
     #
     #   2. `code` CLI on PATH and the user hasn't opted out: write a one-shot
-    #      sentinel containing the handoff prompt, open VS Code at this repo,
-    #      and exit. VS Code's runOn:folderOpen task picks up the sentinel and
-    #      hands off to claude inside the integrated terminal -- so users get
-    #      the file tree, source control panel, and IDE around their session
-    #      instead of a bare PowerShell window. ELNORA_SKIP_VSCODE_HANDOFF=1 is
-    #      the user-facing escape hatch.
+    #      sentinel containing the handoff prompt (plus a sibling file naming
+    #      the chosen agent), open VS Code at this repo, and exit. VS Code's
+    #      runOn:folderOpen task picks up the sentinel and hands off to the
+    #      agent (claude or codex) inside the integrated terminal -- so users
+    #      get the file tree, source control panel, and IDE around their
+    #      session instead of a bare PowerShell window.
+    #      ELNORA_SKIP_VSCODE_HANDOFF=1 is the user-facing escape hatch.
     #
-    #   3. Fallback: claude in this shell (today's behavior). Triggered when
-    #      VS Code wasn't installed (ELNORA_SKIP_OPTIONAL_INSTALLS=1) or the
-    #      `code` shim isn't on PATH yet.
+    #   3. Fallback: the agent in this shell (today's behavior). Triggered
+    #      when VS Code wasn't installed (ELNORA_SKIP_OPTIONAL_INSTALLS=1) or
+    #      the `code` shim isn't on PATH yet.
     if ($env:TERM_PROGRAM -eq "vscode") {
         # Already in VS Code, so we don't launch a window -- but still drop the
         # named workspace file and set restoreWindows so the NEXT relaunch
@@ -1750,26 +1839,27 @@ if ($agentAvailable) {
         exit $LASTEXITCODE
     }
 
-    # The VS Code sentinel handoff drives `claude` specifically (run-handoff.ps1
-    # invokes claude), so it only applies when Claude is the handoff agent. Codex
-    # falls through to the terminal call below.
     $codeAvailable = Get-Command code -ErrorAction SilentlyContinue
-    if ($agentBin -eq 'claude' -and $codeAvailable -and $env:ELNORA_SKIP_VSCODE_HANDOFF -ne "1") {
-        $vscodeDir = Join-Path $scriptDir ".vscode"
-        $sentinel  = Join-Path $vscodeDir ".handoff-pending"
-        $helper    = Join-Path $vscodeDir "run-handoff.ps1"
+    if ($codeAvailable -and $env:ELNORA_SKIP_VSCODE_HANDOFF -ne "1") {
+        $vscodeDir     = Join-Path $scriptDir ".vscode"
+        $sentinel      = Join-Path $vscodeDir ".handoff-pending"
+        $agentSentinel = Join-Path $vscodeDir ".handoff-agent"
+        $helper        = Join-Path $vscodeDir "run-handoff.ps1"
         if ((Test-Path -LiteralPath $vscodeDir) -and (Test-Path -LiteralPath $helper)) {
             # The sentinel's content IS the prompt -- single source of truth
-            # lives in $HandoffPrompt above. The helper reads, deletes, then
-            # invokes claude. BOM-less UTF-8 to keep Get-Content -Raw clean.
+            # lives in $HandoffPrompt above. The sibling agent file names the
+            # agent the helper should launch (claude or codex). The helper
+            # reads both, deletes both, then invokes the agent. BOM-less
+            # UTF-8 to keep Get-Content -Raw clean.
             [System.IO.File]::WriteAllText($sentinel, $HandoffPrompt, [System.Text.UTF8Encoding]::new($false))
+            [System.IO.File]::WriteAllText($agentSentinel, $agentBin, [System.Text.UTF8Encoding]::new($false))
 
             # Create the named workspace file + set restoreWindows BEFORE we
             # open, so we open the workspace (not the bare folder) and the
             # window sticks across relaunches.
             try { Initialize-VSCodeWorkspace } catch { }
 
-            Write-Host "Opening VS Code - Claude will continue Phase 2 setup there." -ForegroundColor White
+            Write-Host "Opening VS Code - $agentName will continue Phase 2 setup there." -ForegroundColor White
             Write-Host ""
             Write-Host "VS Code will show TWO one-time prompts before the handoff fires."
             Write-Host "Click through both:"
@@ -1779,11 +1869,10 @@ if ($agentAvailable) {
             Write-Host "      automatically. Do you want to allow automatic tasks ...?'"
             Write-Host "       -> Click 'Allow'  (VS Code remembers this globally)"
             Write-Host ""
-            Write-Host "Once both are approved, an integrated terminal opens with Claude"
-            Write-Host "already on the Phase 2 prompt. On first run, your browser will"
-            Write-Host "open to log into your Claude Pro/Max account."
+            Write-Host "Once both are approved, an integrated terminal opens with $agentName"
+            Write-Host "already on the Phase 2 prompt. $authNote"
             Write-Host ""
-            Write-Host "If you click Disallow on the second prompt, or Claude does not"
+            Write-Host "If you click Disallow on the second prompt, or $agentName does not"
             Write-Host "auto-start for any other reason, open a terminal in VS Code"
             Write-Host "(Ctrl+`` or View > Terminal) and run:"
             Write-Host "    powershell -ExecutionPolicy Bypass -File .vscode\run-handoff.ps1"
@@ -1808,6 +1897,7 @@ if ($agentAvailable) {
             }
             Write-Host "  [!] Falling back to terminal handoff." -ForegroundColor Yellow
             Remove-Item -LiteralPath $sentinel -Force -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath $agentSentinel -Force -ErrorAction SilentlyContinue
         }
     }
 


### PR DESCRIPTION
## Summary

Completes the claude|codex agent-selection work whose setup-script half already shipped on `main`, in two pieces:

**1. VS Code handoff launches the chosen agent**
- `run-handoff.sh` / `run-handoff.ps1` now read the `.vscode/.handoff-agent` sentinel the setup scripts already write, allowlist its value to `claude` | `codex` (anything else collapses to the `claude` default, which also covers pre-agent-file installs), delete it alongside the prompt sentinel, and exec the chosen agent.
- `tasks.json` label and comments, `.gitignore`, and `RECOVERY.md` §6 updated to the agent-neutral flow.

**2. Agent language choice in Phase 1 setup**
- `setup-mac.sh` / `setup-windows.ps1` ask which language the agent should speak before it ever starts.
- Claude Code: sets the `language` key in `.claude/settings.json` (the exact key `/config` → Language writes) via a node JSON edit — never sed.
- Codex: appends a marker-bounded `## Language` section to `AGENTS.md` (auto-read at session start).
- Both: a sentence appended to the handoff prompt as belt-and-suspenders.
- English (the Enter default) changes nothing — no file writes, no prompt suffix — so the headless/CI handoff prompt stays byte-for-byte identical. The prompt is skipped entirely in CI / headless / no-TTY runs.
- Re-runs are idempotent (the AGENTS.md block is stripped and rewritten, never duplicated); re-running and reverting to English undoes both writes.

## Test plan

- [x] `bash -n setup-mac.sh` and `bash -n .vscode/run-handoff.sh` pass
- [ ] handoff-e2e workflow (CI) green for both `claude` and `codex` agent inputs
- [ ] Manual: fresh install on macOS picking a non-English language; verify `.claude/settings.json` gains `language` and `AGENTS.md` gains the bounded block; re-run choosing English and verify both are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)