### PR TITLE
chore: add a security disclosure policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ckivisild-elnora-ai

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,11 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+By participating in this project, you agree to abide by its terms.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please contact us at [conduct@elnora.ai](mailto:conduct@elnora.ai).
+
+All reports will be reviewed and investigated promptly and fairly. All community leaders are obligated to respect the privacy and security of the reporter.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thank you for considering a contribution.
+
+## Before you start
+
+For anything more than a typo, open an issue first and describe what you intend to change. It is
+cheaper for both of us to disagree about an approach in an issue than in a finished pull request.
+
+## Working on a change
+
+1. Fork the repository and branch from `main`.
+2. Name the branch for what it does: `feat/short-description`, `fix/short-description`,
+   `docs/short-description`.
+3. Keep the change to one purpose. A pull request that fixes a bug and also reformats four files is
+   hard to review and harder to revert.
+4. Match the surrounding code. Every file here already has a style; follow the file you are in rather
+   than the style you prefer.
+5. Run whatever the repository uses to build, lint and test before you open the pull request. Check
+   the README for the commands, and if a check does not exist for what you changed, say so in the
+   pull request rather than leaving the reviewer to guess.
+
+## Commit messages
+
+Conventional Commits: `type(scope): subject`. Types in use are `feat`, `fix`, `docs`, `refactor`,
+`test`, `chore` and `security`. Write the subject as what the change does, not what you did.
+
+## Pull requests
+
+Explain what changes and why. If the reasoning is not obvious from the diff, the pull request body is
+where it belongs, because that is what someone reads in a year when deciding whether the change can
+be reverted.
+
+State what you actually ran. "Builds and tests pass" is only useful when it is true and specific.
+
+## Never commit
+
+Credentials of any kind: API keys, tokens, OAuth client secrets, private keys, `.env` files, exported
+credential JSON. This is enforced by a secret scan on every push and pull request, and by GitHub push
+protection, but neither is a substitute for checking your own diff.
+
+Nor customer names, account identifiers, internal hostnames, or anything else that identifies a
+specific organisation. Use `example.com` and obvious placeholders.
+
+If you believe a secret has already been committed, do not open a pull request removing it. Follow
+[SECURITY.md](./SECURITY.md) instead, because the value is in the history and needs rotating rather
+than deleting.
+
+## Reporting a security problem
+
+Do not open an issue. See [SECURITY.md](./SECURITY.md).
+
+## Licence
+
+Contributions are accepted under the licence in [LICENSE](../LICENSE).

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,62 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x.x   | Yes       |
+
+## Reporting a Vulnerability
+
+**DO NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security vulnerabilities via one of the following channels:
+
+- **Email:** [security@elnora.ai](mailto:security@elnora.ai)
+- **GitHub Security Advisories:** [Report a vulnerability](https://github.com/Elnora-AI/elnora-ai-agent-hackathon-starter-kit/security/advisories/new)
+
+Include as much detail as possible:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+## Response Timeline
+
+- **Acknowledgement:** Within 48 hours of report
+- **Initial assessment:** Within 5 business days
+- **Fix and disclosure:** Within 90 days of report
+
+## Responsible Disclosure
+
+We follow a 90-day disclosure timeline. We ask that you:
+
+- Allow us reasonable time to fix the issue before public disclosure
+- Do not access or modify other users' data
+- Do not perform actions that could negatively impact other users
+- Act in good faith to avoid privacy violations, data destruction, and service disruption
+
+## Scope
+
+**In scope:**
+
+- The `elnora-ai-agent-hackathon-starter-kit` CLI and plugin code in this repository
+- Configuration handling (`references/*.json`, env var resolution, API-key storage)
+- Signal sources implemented in this repo (currently only `external_command`; the other source types in `schemas/signal-sources.json` are declared but not yet implemented)
+
+**Out of scope:**
+
+- Third-party dependencies (please report to their respective maintainers)
+- The Linear API itself (report to Linear)
+- User-configured `external_command` entries — those execute commands the user has chosen to trust
+- Social engineering attacks against Elnora staff
+- Denial of service attacks
+- Issues in services not operated by Elnora
+
+## Security Best Practices for Users
+
+- Never commit API keys or tokens to version control
+- The plugin saves your Linear API key to `~/.config/elnora-ai-agent-hackathon-starter-kit/.env` with mode `0600` by default — verify this if you suspect tampering
+- Rotate your Linear API key periodically via Linear's account settings
+- When configuring `external_command` signal sources, only point at trusted local binaries


### PR DESCRIPTION
Adds the security disclosure policy this repository was missing.

It is public and had no `SECURITY.md`, so a researcher finding a vulnerability had no private route to report it. The path of least resistance is then a public issue, which discloses the problem to everyone at the moment it reaches us.

Content matches the policy already carried by the other published repositories: the security address, the GitHub private advisory route, what to include, and the acknowledgement, assessment and disclosure timelines.

Found by auditing control parity across all 16 public repositories.